### PR TITLE
Add configurable custom verification URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For .NET Framework or for other older .NET versions, please use a version below 
 - [Basic Usage](#basic-usage)
 - [Verification Process](#verification-process)
 - [Configuring Actions and Score Thresholds](#configuring-actions-and-score-thresholds)
+- [Custom Verification URL](#custom-verification-url)
 - [Response Customization](#response-customization)
 - [Handling Exceptions](#handling-exceptions)
 - [Examples](#examples)
@@ -156,7 +157,7 @@ The service returns a `ValidationResult` object with detailed validation status.
 |`IsV3`|`bool`|Indicates whether this is a reCAPTCHA v3 verification (based on score presence)|
 |`ActionMatches`|`bool`|Indicates whether the action matches the expected value|
 |`ScoreSatisfies`|`bool`|Indicates whether the score meets the required threshold|
-|`Success`|`bool`|**Overall validation result** — `true` only when all applicable checks pass|
+|`Success`|`bool`|**Overall validation result** â€” `true` only when all applicable checks pass|
 
 ## Configuring Actions and Score Thresholds
 For reCAPTCHA v3 validation, both an action and a score threshold must be specified.
@@ -206,6 +207,34 @@ public IActionResult Login() { ... }
 [Recaptcha("comment", 0.4)]
 public IActionResult AddComment() { ... }
 ```
+
+## Custom Verification URL
+By default, the library communicates with Google's reCAPTCHA API at `https://www.google.com/recaptcha/api`.
+To use a custom endpoint (e.g. a mirror or proxy), set the `BaseUrl` option in `RecaptchaOptions`:
+
+### Via appsettings.json
+```json
+{
+  "Recaptcha": {
+    "SecretKey": "<recaptcha secret key>",
+    "BaseUrl": "https://recaptcha-proxy.example.com/recaptcha/api",
+    "AttributeOptions": {
+      "ResponseTokenNameInHeader": "X-Recaptcha-Token"
+    }
+  }
+}
+```
+
+### Via code configuration
+```csharp
+services.AddRecaptcha(o =>
+{
+    o.SecretKey = "<recaptcha secret key>";
+    o.BaseUrl = "https://recaptcha-proxy.example.com/recaptcha/api";
+});
+```
+
+When `BaseUrl` is not specified, the default Google endpoint is used.
 
 ## Response Customization
 When reCAPTCHA verification fails or an exception occurs (will not catch exceptions in future versions), the library returns a `400 Bad Request` response by default.

--- a/Recaptcha.Verify.Net.Test/Configuration/ConfigurationExtensionsTest.cs
+++ b/Recaptcha.Verify.Net.Test/Configuration/ConfigurationExtensionsTest.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.DependencyInjection;
+using Recaptcha.Verify.Net.Configuration;
+using Recaptcha.Verify.Net.TokenVerification.Client;
+using Xunit;
+
+namespace Recaptcha.Verify.Net.Test.Configuration;
+
+public class ConfigurationExtensionsTest
+{
+    private const string SecretKey = "test-secret";
+    private const string DefaultBaseUrl = "https://www.google.com/recaptcha/api/";
+    private const string CustomBaseUrl = "https://recaptcha-proxy.example.com/recaptcha/api";
+    private const string CustomBaseUrlWithSlash = "https://recaptcha-proxy.example.com/recaptcha/api/";
+
+    [Fact]
+    public void AddRecaptcha_DefaultBaseUrl_WhenNotSpecified() =>
+        AssertBaseAddress(DefaultBaseUrl, o => o.SecretKey = SecretKey);
+
+    [Fact]
+    public void AddRecaptcha_CustomBaseUrl_WhenSpecified() =>
+        AssertBaseAddress(CustomBaseUrlWithSlash, o =>
+        {
+            o.SecretKey = SecretKey;
+            o.BaseUrl = CustomBaseUrl;
+        });
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddRecaptcha_DefaultBaseUrl_WhenNullOrEmpty(string? baseUrl) =>
+        AssertBaseAddress(DefaultBaseUrl, o =>
+        {
+            o.SecretKey = SecretKey;
+            o.BaseUrl = baseUrl;
+        });
+
+    [Fact]
+    public void AddRecaptcha_AppendsTrailingSlash_WhenMissing() =>
+        AssertBaseAddress(CustomBaseUrlWithSlash, o =>
+        {
+            o.SecretKey = SecretKey;
+            o.BaseUrl = CustomBaseUrl;
+        });
+
+    [Fact]
+    public void AddRecaptcha_PreservesTrailingSlash_WhenPresent() =>
+        AssertBaseAddress(CustomBaseUrlWithSlash, o =>
+        {
+            o.SecretKey = SecretKey;
+            o.BaseUrl = CustomBaseUrlWithSlash;
+        });
+
+    private static void AssertBaseAddress(string expectedUrl, Action<RecaptchaOptions> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddRecaptcha(configure);
+
+        using var provider = services.BuildServiceProvider();
+        var client = (RecaptchaClient)provider.GetRequiredService<IRecaptchaClient>();
+
+        Assert.Equal(new Uri(expectedUrl), GetBaseAddress(client));
+    }
+
+    private static Uri GetBaseAddress(RecaptchaClient client)
+    {
+        var httpClientField = client.GetType().GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .First(f => f.FieldType == typeof(HttpClient));
+
+        var httpClient = (HttpClient)httpClientField.GetValue(client)!;
+        return httpClient.BaseAddress!;
+    }
+}

--- a/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
+++ b/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
@@ -10,7 +10,7 @@ namespace Recaptcha.Verify.Net.Configuration;
 /// </summary>
 public static class ConfigurationExtensions
 {
-    private const string _baseUrl = "https://www.google.com/recaptcha/api";
+    private const string DefaultBaseUrl = "https://www.google.com/recaptcha/api";
 
     /// <summary>
     /// Registers <see cref="IRecaptchaVerificationResultValidationService"/> implementation for usage with dependency injection.
@@ -48,7 +48,7 @@ public static class ConfigurationExtensions
 
         services.AddTokenExtractorForOptions(recaptchaOptions);
 
-        services.ConfigureService();
+        services.ConfigureService(recaptchaOptions.BaseUrl);
 
         return services;
     }
@@ -136,10 +136,11 @@ public static class ConfigurationExtensions
     public static IServiceCollection AddRecaptchaQueryTokenExtractor(this IServiceCollection services, string parameterName) =>
         services.AddSingleton<IRecaptchaTokenExtractor, QueryTokenExtractor>(_ => new QueryTokenExtractor(parameterName));
 
-    private static void ConfigureService(this IServiceCollection services)
+    private static void ConfigureService(this IServiceCollection services, string? baseUrl)
     {
+        var url = !string.IsNullOrWhiteSpace(baseUrl) ? baseUrl : DefaultBaseUrl;
         services.AddHttpClient<IRecaptchaClient, RecaptchaClient>(client =>
-            client.BaseAddress = new Uri(_baseUrl.EndsWith('/') ? _baseUrl : $"{_baseUrl}/"));
+            client.BaseAddress = new Uri(url.EndsWith('/') ? url : $"{url}/"));
 
         services.AddScoped<IRecaptchaVerificationService, RecaptchaVerificationService>();
         services.AddScoped<IRecaptchaVerificationResultValidationService, RecaptchaVerificationResultValidationService>();

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
@@ -13,6 +13,13 @@ public class RecaptchaOptions
     public string SecretKey { get; set; } = null!;
 
     /// <summary>
+    /// Optional. Custom base URL for the reCAPTCHA verification API endpoint.
+    /// <para>When not specified, defaults to <c>https://www.google.com/recaptcha/api</c>.</para>
+    /// <para>Set this to use a custom endpoint, such as a reCAPTCHA mirror or proxy server.</para>
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
     /// Optional. Action to check for V3 Recaptcha request.
     /// <para>Action specified in <see cref="IRecaptchaVerificationResultValidationService.Validate"/>
     /// or in <see cref="RecaptchaAttribute"/> will be used instead of this value.</para>


### PR DESCRIPTION
Added `BaseUrl` property to `RecaptchaOptions` allowing custom reCAPTCHA verification endpoint (mirror/proxy).

- `RecaptchaOptions.BaseUrl` (string?, default: null) â€” custom base URL
- Falls back to `https://www.google.com/recaptcha/api` when not set
- Handles trailing slash normalization
- Includes unit tests