### PR TITLE
Extract token extraction logic into IRecaptchaTokenExtractionService

### DIFF
--- a/Recaptcha.Verify.Net.Test/Attribute/ActionExecutingContextFixture.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/ActionExecutingContextFixture.cs
@@ -18,24 +18,15 @@ internal class ActionExecutingContextFixture
 {
     public static readonly IPAddress IPAddress = new(int.MaxValue);
 
-    public static IRecaptchaTokenExtractor CreateTokenExtractor(string? token)
-    {
-        var extractor = new Mock<IRecaptchaTokenExtractor>();
-
-        extractor.Setup(x => x.GetToken(It.IsAny<ActionExecutingContext>())).Returns(token);
-
-        return extractor.Object;
-    }
-
     public static (ActionExecutingContext context, Mock<ActionExecutionDelegate> nextMock) CreateActionExecutingContext(
         RecaptchaOptions? options,
-        IEnumerable<IRecaptchaTokenExtractor>? tokenExtractors,
+        IRecaptchaTokenExtractionService? tokenExtractionService,
         IRecaptchaVerificationService? verificationService,
         IRecaptchaVerificationResultValidationService? validationService)
     {
         var actionsArguments = new Dictionary<string, object?>();
 
-        var httpContext = CreateHttpContext(options, tokenExtractors, verificationService, validationService);
+        var httpContext = CreateHttpContext(options, tokenExtractionService, verificationService, validationService);
 
         var actionContext = new ActionContext
         {
@@ -59,7 +50,7 @@ internal class ActionExecutingContextFixture
 
     private static HttpContextMock CreateHttpContext(
         RecaptchaOptions? options,
-        IEnumerable<IRecaptchaTokenExtractor>? tokenExtractors,
+        IRecaptchaTokenExtractionService? tokenExtractionService,
         IRecaptchaVerificationService? verificationService,
         IRecaptchaVerificationResultValidationService? validationService)
     {
@@ -70,7 +61,10 @@ internal class ActionExecutingContextFixture
             httpContext.SetupRequestService(Options.Create(options));
         }
 
-        httpContext.SetupRequestService(tokenExtractors ?? []);
+        if (tokenExtractionService is not null)
+        {
+            httpContext.SetupRequestService(tokenExtractionService);
+        }
 
         if (verificationService is not null)
         {

--- a/Recaptcha.Verify.Net.Test/Attribute/AttributeTest.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/AttributeTest.cs
@@ -1,8 +1,12 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Moq;
 using Recaptcha.Verify.Net.Attribute;
 using Recaptcha.Verify.Net.Configuration;
+using Recaptcha.Verify.Net.Exceptions.Configuration;
+using Recaptcha.Verify.Net.Exceptions.Processing;
+using Recaptcha.Verify.Net.TokenExtraction;
 using Recaptcha.Verify.Net.TokenVerification;
 using Recaptcha.Verify.Net.TokenVerification.Client.Models.Response;
 using Recaptcha.Verify.Net.VerificationResultValidation;
@@ -13,8 +17,6 @@ namespace Recaptcha.Verify.Net.Test.Attribute;
 
 public class AttributeTest
 {
-    public static TheoryData<string?> EmptyStrings => new(null, string.Empty, "   ");
-
     public static TheoryData<bool> BooleanValues => new(false, true);
 
     public static TheoryData<bool, string?, float?> GetExecuteParameters()
@@ -36,7 +38,7 @@ public class AttributeTest
     }
 
     [Fact]
-    public async Task Execute_NoTokenExtractorRegistered_ReturnsBadRequest()
+    public async Task Execute_NoTokenExtractionService_ReturnsBadRequest()
     {
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions();
 
@@ -53,16 +55,38 @@ public class AttributeTest
         Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
-    [Theory]
-    [MemberData(nameof(EmptyStrings))]
-    public async Task Execute_TokenExtractorReturnsEmpty_ReturnsBadRequest(string? token)
+    [Fact]
+    public async Task Execute_TokenExtractionServiceThrowsTokenExtractorNotFound_ReturnsBadRequest()
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices([token]);
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            null, extractionException: new TokenExtractorNotFound());
 
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions();
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
+
+        var attribute = new RecaptchaAttribute();
+
+        await attribute.OnActionExecutionAsync(context, next.Object);
+
+        next.Verify(x => x.Invoke(), Times.Never);
+
+        Assert.NotNull(context.Result);
+        Assert.True(context.Result is BadRequestObjectResult);
+        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
+    }
+
+    [Fact]
+    public async Task Execute_TokenExtractionServiceThrowsEmptyCaptchaAnswer_ReturnsBadRequest()
+    {
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            null, extractionException: new EmptyCaptchaAnswerException());
+
+        var options = RecaptchaAttributeFixture.GetRecaptchaOptions();
+
+        (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = new RecaptchaAttribute();
 
@@ -79,8 +103,8 @@ public class AttributeTest
     [MemberData(nameof(BooleanValues))]
     public async Task Execute_v2_Successful(bool useCancellationToken)
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [RecaptchaAttributeFixture.Token],
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            RecaptchaAttributeFixture.Token,
             new VerifyResponse(),
             new ValidationResult
             {
@@ -91,13 +115,13 @@ public class AttributeTest
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = new RecaptchaAttribute();
 
         await attribute.OnActionExecutionAsync(context, next.Object);
 
-        VerifyServicesCalls(verificationService, validationService, true, useCancellationToken, null, null);
+        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, true, useCancellationToken, null, null);
 
         next.Verify(x => x.Invoke(), Times.Once);
 
@@ -108,8 +132,8 @@ public class AttributeTest
     [MemberData(nameof(GetExecuteParameters))]
     public async Task Execute_v3_Successful(bool useCancellationToken, string? action, float? score)
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [RecaptchaAttributeFixture.Token],
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            RecaptchaAttributeFixture.Token,
             new VerifyResponse(),
             new ValidationResult
             {
@@ -122,44 +146,13 @@ public class AttributeTest
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
         await attribute.OnActionExecutionAsync(context, next.Object);
 
-        VerifyServicesCalls(verificationService, validationService, true, useCancellationToken, action, score);
-
-        next.Verify(x => x.Invoke(), Times.Once);
-
-        Assert.Null(context.Result);
-    }
-
-    [Theory]
-    [MemberData(nameof(EmptyStrings))]
-    public async Task Execute_v3_MultipleTokenExtractors_Successful(string? emptyToken)
-    {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [emptyToken, RecaptchaAttributeFixture.Token],
-            new VerifyResponse(),
-            new ValidationResult
-            {
-                ResponseSuccessful = true,
-                IsV3 = true,
-                ScoreSatisfies = true,
-                ActionMatches = true
-            });
-
-        var options = RecaptchaAttributeFixture.GetRecaptchaOptions();
-
-        (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
-
-        var attribute = new RecaptchaAttribute();
-
-        await attribute.OnActionExecutionAsync(context, next.Object);
-
-        VerifyServicesCalls(verificationService, validationService, true, false, null, null);
+        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, true, useCancellationToken, action, score);
 
         next.Verify(x => x.Invoke(), Times.Once);
 
@@ -170,8 +163,8 @@ public class AttributeTest
     [MemberData(nameof(GetExecuteParameters))]
     public async Task Execute_Unuccessful_ReturnsBadRequest(bool useCancellationToken, string? action, float? score)
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [RecaptchaAttributeFixture.Token],
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            RecaptchaAttributeFixture.Token,
             new VerifyResponse(),
             new ValidationResult
             {
@@ -182,13 +175,13 @@ public class AttributeTest
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
         await attribute.OnActionExecutionAsync(context, next.Object);
 
-        VerifyServicesCalls(verificationService, validationService, true, useCancellationToken, action, score);
+        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, true, useCancellationToken, action, score);
 
         next.Verify(x => x.Invoke(), Times.Never);
 
@@ -201,26 +194,26 @@ public class AttributeTest
     [MemberData(nameof(GetExecuteParameters))]
     public async Task Execute_VerificationThrows_ReturnsBadRequest(bool useCancellationToken, string? action, float? score)
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [RecaptchaAttributeFixture.Token],
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            RecaptchaAttributeFixture.Token,
             null,
             new ValidationResult
             {
                 ResponseSuccessful = false,
                 IsV3 = true
             },
-            new Exception());
+            verificationException: new Exception());
 
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
         await attribute.OnActionExecutionAsync(context, next.Object);
 
-        VerifyServicesCalls(verificationService, validationService, false, useCancellationToken, action, score);
+        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, false, useCancellationToken, action, score);
 
         next.Verify(x => x.Invoke(), Times.Never);
 
@@ -233,23 +226,21 @@ public class AttributeTest
     [MemberData(nameof(GetExecuteParameters))]
     public async Task Execute_ValidationThrows_ReturnsBadRequest(bool useCancellationToken, string? action, float? score)
     {
-        (var tokenExtractors, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
-            [RecaptchaAttributeFixture.Token],
+        (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
+            RecaptchaAttributeFixture.Token,
             new VerifyResponse(),
-            null,
-            null,
-            new Exception());
+            validationException: new Exception());
 
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
         (var context, var next) = ActionExecutingContextFixture.CreateActionExecutingContext(
-            options, tokenExtractors, verificationService.Object, validationService.Object);
+            options, tokenExtractionService.Object, verificationService.Object, validationService.Object);
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
         await attribute.OnActionExecutionAsync(context, next.Object);
 
-        VerifyServicesCalls(verificationService, validationService, true, useCancellationToken, action, score);
+        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, true, useCancellationToken, action, score);
 
         next.Verify(x => x.Invoke(), Times.Never);
 
@@ -259,6 +250,7 @@ public class AttributeTest
     }
 
     private static void VerifyServicesCalls(
+        Mock<IRecaptchaTokenExtractionService> tokenExtractionService,
         Mock<IRecaptchaVerificationService> verificationService,
         Mock<IRecaptchaVerificationResultValidationService> validationService,
         bool validationExecuted,
@@ -266,6 +258,8 @@ public class AttributeTest
         string? action,
         float? score)
     {
+        tokenExtractionService.Verify(x => x.GetToken(It.IsAny<ActionExecutingContext>()), Times.Once);
+
         verificationService.Verify(
             x => x.VerifyAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);

--- a/Recaptcha.Verify.Net.Test/Attribute/RecaptchaAttributeFixture.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/RecaptchaAttributeFixture.cs
@@ -1,11 +1,13 @@
-﻿using Moq;
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Moq;
 using Recaptcha.Verify.Net.Configuration;
+using Recaptcha.Verify.Net.TokenExtraction;
 using Recaptcha.Verify.Net.TokenVerification;
 using Recaptcha.Verify.Net.TokenVerification.Client.Models.Response;
 using Recaptcha.Verify.Net.VerificationResultValidation;
 using Recaptcha.Verify.Net.VerificationResultValidation.Models;
 using RecaptchaServices = (
-    Recaptcha.Verify.Net.TokenExtraction.IRecaptchaTokenExtractor[] tokenExtractors,
+    Moq.Mock<Recaptcha.Verify.Net.TokenExtraction.IRecaptchaTokenExtractionService> tokenExtractionService,
     Moq.Mock<Recaptcha.Verify.Net.TokenVerification.IRecaptchaVerificationService> verificationService,
     Moq.Mock<Recaptcha.Verify.Net.VerificationResultValidation.IRecaptchaVerificationResultValidationService> validationService);
 
@@ -25,11 +27,20 @@ internal static class RecaptchaAttributeFixture
         }
     };
 
-    public static RecaptchaServices CreateServices(string?[] tokens,
+    public static RecaptchaServices CreateServices(string? token,
         VerifyResponse? verificationResult = null, ValidationResult? validationResult = null,
-        Exception? verificationException = null, Exception? validationException = null)
+        Exception? extractionException = null, Exception? verificationException = null, Exception? validationException = null)
     {
-        var tokenExtractors = tokens.Select(ActionExecutingContextFixture.CreateTokenExtractor).ToArray();
+        var tokenExtractionService = new Mock<IRecaptchaTokenExtractionService>();
+
+        if (extractionException is not null)
+        {
+            tokenExtractionService.Setup(x => x.GetToken(It.IsAny<ActionExecutingContext>())).Throws(extractionException);
+        }
+        else
+        {
+            tokenExtractionService.Setup(x => x.GetToken(It.IsAny<ActionExecutingContext>())).Returns(token!);
+        }
 
         var verificationService = new Mock<IRecaptchaVerificationService>();
 
@@ -61,6 +72,6 @@ internal static class RecaptchaAttributeFixture
                 .Throws(validationException);
         }
 
-        return (tokenExtractors, verificationService, validationService);
+        return (tokenExtractionService, verificationService, validationService);
     }
 }

--- a/Recaptcha.Verify.Net.Test/TokenExtraction/TokenExtractionServiceTest.cs
+++ b/Recaptcha.Verify.Net.Test/TokenExtraction/TokenExtractionServiceTest.cs
@@ -1,0 +1,83 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Moq;
+using Recaptcha.Verify.Net.Exceptions.Configuration;
+using Recaptcha.Verify.Net.Exceptions.Processing;
+using Recaptcha.Verify.Net.TokenExtraction;
+using Xunit;
+
+namespace Recaptcha.Verify.Net.Test.TokenExtraction;
+
+public class TokenExtractionServiceTest
+{
+    private const string Token = "TestToken";
+    private const string OtherToken = "OtherToken";
+
+    [Fact]
+    public void GetToken_NoExtractors_ThrowsTokenExtractorNotFound()
+    {
+        var service = new RecaptchaTokenExtractionService([]);
+        var context = ActionExecutingContextFixture.CreateActionExecutingContext();
+
+        Assert.Throws<TokenExtractorNotFound>(() => service.GetToken(context));
+    }
+
+    [Fact]
+    public void GetToken_AllExtractorsReturnEmpty_ThrowsEmptyCaptchaAnswer()
+    {
+        var extractors = new[]
+        {
+            CreateExtractor(null).Object,
+            CreateExtractor(string.Empty).Object,
+            CreateExtractor("   ").Object,
+        };
+        var service = new RecaptchaTokenExtractionService(extractors);
+        var context = ActionExecutingContextFixture.CreateActionExecutingContext();
+
+        Assert.Throws<EmptyCaptchaAnswerException>(() => service.GetToken(context));
+    }
+
+    [Fact]
+    public void GetToken_SingleExtractorReturnsToken_ReturnsToken()
+    {
+        var service = new RecaptchaTokenExtractionService([CreateExtractor(Token).Object]);
+        var context = ActionExecutingContextFixture.CreateActionExecutingContext();
+
+        var result = service.GetToken(context);
+
+        Assert.Equal(Token, result);
+    }
+
+    [Fact]
+    public void GetToken_FirstEmptySecondReturnsToken_ReturnsToken()
+    {
+        var service = new RecaptchaTokenExtractionService([CreateExtractor(null).Object, CreateExtractor(Token).Object]);
+        var context = ActionExecutingContextFixture.CreateActionExecutingContext();
+
+        var result = service.GetToken(context);
+
+        Assert.Equal(Token, result);
+    }
+
+    [Fact]
+    public void GetToken_FirstWins_SecondExtractorNotCalled()
+    {
+        var firstExtractor = CreateExtractor(Token);
+        var secondExtractor = CreateExtractor(OtherToken);
+
+        var service = new RecaptchaTokenExtractionService([firstExtractor.Object, secondExtractor.Object]);
+        var context = ActionExecutingContextFixture.CreateActionExecutingContext();
+
+        var result = service.GetToken(context);
+
+        Assert.Equal(Token, result);
+        firstExtractor.Verify(x => x.GetToken(context), Times.Once);
+        secondExtractor.Verify(x => x.GetToken(It.IsAny<ActionExecutingContext>()), Times.Never);
+    }
+
+    private static Mock<IRecaptchaTokenExtractor> CreateExtractor(string? token)
+    {
+        var extractor = new Mock<IRecaptchaTokenExtractor>();
+        extractor.Setup(x => x.GetToken(It.IsAny<ActionExecutingContext>())).Returns(token);
+        return extractor;
+    }
+}

--- a/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
+++ b/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
@@ -80,7 +80,8 @@ public class RecaptchaAttribute : ActionFilterAttribute
 
     private async Task<IActionResult?> ProcessRecaptchaAsync(ActionExecutingContext context, RecaptchaOptions recaptchaOptions)
     {
-        var recaptchaToken = GetRecaptchaToken(context);
+        var tokenExtractionService = context.HttpContext.RequestServices.GetRequiredService<IRecaptchaTokenExtractionService>();
+        var recaptchaToken = tokenExtractionService.GetToken(context);
 
         var verificationService = context.HttpContext.RequestServices.GetRequiredService<IRecaptchaVerificationService>();
         var validationService = context.HttpContext.RequestServices.GetRequiredService<IRecaptchaVerificationResultValidationService>();
@@ -101,39 +102,5 @@ public class RecaptchaAttribute : ActionFilterAttribute
         }
 
         return null;
-    }
-
-    private static string GetRecaptchaToken(ActionExecutingContext context)
-    {
-        var tokenExtractors = context.HttpContext.RequestServices.GetServices<IRecaptchaTokenExtractor>();
-
-        string? recaptchaToken = null;
-        var recaptchaTokenExtracted = false;
-        var tokenExtractorsCount = 0;
-
-        foreach (var tokenExtractor in tokenExtractors)
-        {
-            tokenExtractorsCount++;
-
-            recaptchaToken = tokenExtractor.GetToken(context);
-
-            if (!string.IsNullOrWhiteSpace(recaptchaToken))
-            {
-                recaptchaTokenExtracted = true;
-                break;
-            }
-        }
-
-        if (tokenExtractorsCount == 0)
-        {
-            throw new TokenExtractorNotFound();
-        }
-
-        if (!recaptchaTokenExtracted)
-        {
-            throw new EmptyCaptchaAnswerException();
-        }
-
-        return recaptchaToken!;
     }
 }

--- a/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
+++ b/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
@@ -141,6 +141,7 @@ public static class ConfigurationExtensions
         services.AddHttpClient<IRecaptchaClient, RecaptchaClient>(client =>
             client.BaseAddress = new Uri(_baseUrl.EndsWith('/') ? _baseUrl : $"{_baseUrl}/"));
 
+        services.AddScoped<IRecaptchaTokenExtractionService, RecaptchaTokenExtractionService>();
         services.AddScoped<IRecaptchaVerificationService, RecaptchaVerificationService>();
         services.AddScoped<IRecaptchaVerificationResultValidationService, RecaptchaVerificationResultValidationService>();
     }

--- a/Recaptcha.Verify.Net/TokenExtraction/IRecaptchaTokenExtractionService.cs
+++ b/Recaptcha.Verify.Net/TokenExtraction/IRecaptchaTokenExtractionService.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Recaptcha.Verify.Net.TokenExtraction;
+
+/// <summary>
+/// Service for extracting reCAPTCHA response token from the request using registered token extractors.
+/// </summary>
+public interface IRecaptchaTokenExtractionService
+{
+    /// <summary>
+    /// Extracts reCAPTCHA response token from the <see cref="ActionExecutingContext"/>.
+    /// </summary>
+    /// <param name="context">A context for action filters.</param>
+    /// <returns>Extracted reCAPTCHA response token.</returns>
+    /// <exception cref="Exceptions.Processing.EmptyCaptchaAnswerException">
+    /// This exception is thrown when the extracted token is null or empty.
+    /// </exception>
+    /// <exception cref="Exceptions.Configuration.RecaptchaServiceConfigurationException"/>
+    /// <exception cref="Exceptions.Processing.RecaptchaServiceProcessingException"/>
+    string GetToken(ActionExecutingContext context);
+}

--- a/Recaptcha.Verify.Net/TokenExtraction/RecaptchaTokenExtractionService.cs
+++ b/Recaptcha.Verify.Net/TokenExtraction/RecaptchaTokenExtractionService.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Recaptcha.Verify.Net.TokenExtraction;
+
+/// <summary>
+/// Service for extracting reCAPTCHA response token from the request using registered token extractors.
+/// <para>Uses first-wins strategy: returns the first non-empty token found.</para>
+/// </summary>
+/// <exception cref="Exceptions.Configuration.TokenExtractorNotFound">
+/// This exception is thrown when no <see cref="IRecaptchaTokenExtractor"/> implementation is registered in DI.
+/// </exception>
+/// <exception cref="Exceptions.Processing.EmptyCaptchaAnswerException">
+/// This exception is thrown when all registered extractors returned null or empty token.
+/// </exception>
+internal class RecaptchaTokenExtractionService(IEnumerable<IRecaptchaTokenExtractor> tokenExtractors) : IRecaptchaTokenExtractionService
+{
+    /// <inheritdoc />
+    public string GetToken(ActionExecutingContext context)
+    {
+        string? recaptchaToken = null;
+        var recaptchaTokenExtracted = false;
+        var tokenExtractorsCount = 0;
+
+        foreach (var tokenExtractor in tokenExtractors)
+        {
+            tokenExtractorsCount++;
+
+            recaptchaToken = tokenExtractor.GetToken(context);
+
+            if (!string.IsNullOrWhiteSpace(recaptchaToken))
+            {
+                recaptchaTokenExtracted = true;
+                break;
+            }
+        }
+
+        if (tokenExtractorsCount == 0)
+        {
+            throw new TokenExtractorNotFound();
+        }
+
+        if (!recaptchaTokenExtracted)
+        {
+            throw new EmptyCaptchaAnswerException();
+        }
+
+        return recaptchaToken!;
+    }
+}


### PR DESCRIPTION
Extracted `GetRecaptchaToken` from `RecaptchaAttribute` into a new `IRecaptchaTokenExtractionService` / `RecaptchaTokenExtractionService`, following the same pattern as `IRecaptchaVerificationService` and `IRecaptchaVerificationResultValidationService`.

- New `IRecaptchaTokenExtractionService` interface with `GetToken(ActionExecutingContext)`
- `RecaptchaTokenExtractionService` receives `IEnumerable<IRecaptchaTokenExtractor>` via DI
- `RecaptchaAttribute` now resolves the service instead of iterating extractors directly