### PR TITLE
Remove obsolete delegates, make exceptions propagate

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,20 +237,16 @@ services.AddRecaptcha(o =>
 When `BaseUrl` is not specified, the default Google endpoint is used.
 
 ## Response Customization
-When reCAPTCHA verification fails or an exception occurs (will not catch exceptions in future versions), the library returns a `400 Bad Request` response by default.
+When reCAPTCHA verification fails, the library returns a `400 Bad Request` response by default.
 Message specified in `RecaptchaOptions.VerificationFailedMessage` which default value is "Recaptcha verification failed".
 
-|Delegate|Trigger|Status|
-|---|---|---|
-|`OnVerificationFailed`|When token verification or validation fails|Active|
-|`OnRecaptchaServiceException`|When `RecaptchaServiceException` is thrown|Deprecated|
-|`OnException`|When any unhandled exception occurs|Deprecated|
-|`OnReturnBadRequest`|When any failure or exception occurs|Deprecated|
+You can customize the response by setting the `RecaptchaOptions.OnVerificationFailed` delegate, which is called when token verification or validation fails.
+The `IActionResult` returned by this delegate is used as the HTTP response.
+Delegate may also throw exceptions, which will not be caught by `RecaptchaAttribute`.
 
-The `IActionResult` returned by these delegates is used as the HTTP response.
-Delegates may also throw exceptions, which will not be caught by `RecaptchaAttribute`.
-
-Deprecated delegates will be removed in future versions in favor of exception handling middleware.
+When an exception occurs during verification, a `RecaptchaServiceException`-derived exception is thrown (see [Handling Exceptions](#handling-exceptions) for the full list).
+These exceptions are not caught by `RecaptchaAttribute` and propagate up the ASP.NET request pipeline, where they are handled according to the application's configured exception handling rules.
+See the [ASP.NET Core example](https://github.com/vese/Recaptcha.Verify.Net/tree/release/v3.0/examples/Recaptcha.Verify.Net.AspNetCoreAngular) for a reference implementation.
 
 ## Handling Exceptions
 Library can produce following exceptions

--- a/Recaptcha.Verify.Net.Test/Attribute/AttributeTest.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/AttributeTest.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Moq;
 using Recaptcha.Verify.Net.Attribute;
 using Recaptcha.Verify.Net.Configuration;
+using Recaptcha.Verify.Net.Exceptions;
 using Recaptcha.Verify.Net.Exceptions.Configuration;
 using Recaptcha.Verify.Net.Exceptions.Processing;
 using Recaptcha.Verify.Net.TokenExtraction;
@@ -38,7 +39,7 @@ public class AttributeTest
     }
 
     [Fact]
-    public async Task Execute_NoTokenExtractionService_ReturnsBadRequest()
+    public async Task Execute_NoTokenExtractionService_ThrowsRecaptchaUnknownException()
     {
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions();
 
@@ -46,17 +47,14 @@ public class AttributeTest
 
         var attribute = new RecaptchaAttribute();
 
-        await attribute.OnActionExecutionAsync(context, next.Object);
+        var thrown = await Assert.ThrowsAsync<RecaptchaUnknownException>(() => attribute.OnActionExecutionAsync(context, next.Object));
+        Assert.IsType<InvalidOperationException>(thrown.InnerException);
 
         next.Verify(x => x.Invoke(), Times.Never);
-
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result is BadRequestObjectResult);
-        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
     [Fact]
-    public async Task Execute_TokenExtractionServiceThrowsTokenExtractorNotFound_ReturnsBadRequest()
+    public async Task Execute_TokenExtractionServiceThrowsTokenExtractorNotFound_PropagatesException()
     {
         (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
             null, extractionException: new TokenExtractorNotFound());
@@ -68,17 +66,13 @@ public class AttributeTest
 
         var attribute = new RecaptchaAttribute();
 
-        await attribute.OnActionExecutionAsync(context, next.Object);
+        await Assert.ThrowsAsync<TokenExtractorNotFound>(() => attribute.OnActionExecutionAsync(context, next.Object));
 
         next.Verify(x => x.Invoke(), Times.Never);
-
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result is BadRequestObjectResult);
-        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
     [Fact]
-    public async Task Execute_TokenExtractionServiceThrowsEmptyCaptchaAnswer_ReturnsBadRequest()
+    public async Task Execute_TokenExtractionServiceThrowsEmptyCaptchaAnswer_PropagatesException()
     {
         (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
             null, extractionException: new EmptyCaptchaAnswerException());
@@ -90,13 +84,9 @@ public class AttributeTest
 
         var attribute = new RecaptchaAttribute();
 
-        await attribute.OnActionExecutionAsync(context, next.Object);
+        await Assert.ThrowsAsync<EmptyCaptchaAnswerException>(() => attribute.OnActionExecutionAsync(context, next.Object));
 
         next.Verify(x => x.Invoke(), Times.Never);
-
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result is BadRequestObjectResult);
-        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
     [Theory]
@@ -192,8 +182,10 @@ public class AttributeTest
 
     [Theory]
     [MemberData(nameof(GetExecuteParameters))]
-    public async Task Execute_VerificationThrows_ReturnsBadRequest(bool useCancellationToken, string? action, float? score)
+    public async Task Execute_VerificationThrows_PropagatesException(bool useCancellationToken, string? action, float? score)
     {
+        var verificationException = new Exception();
+
         (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
             RecaptchaAttributeFixture.Token,
             null,
@@ -202,7 +194,7 @@ public class AttributeTest
                 ResponseSuccessful = false,
                 IsV3 = true
             },
-            verificationException: new Exception());
+            verificationException: verificationException);
 
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
@@ -211,25 +203,24 @@ public class AttributeTest
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
-        await attribute.OnActionExecutionAsync(context, next.Object);
+        var thrown = await Assert.ThrowsAsync<RecaptchaUnknownException>(() => attribute.OnActionExecutionAsync(context, next.Object));
+        Assert.Same(verificationException, thrown.InnerException);
 
-        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, false, useCancellationToken, action, score);
+        tokenExtractionService.Verify(x => x.GetToken(It.IsAny<ActionExecutingContext>()), Times.Once);
 
         next.Verify(x => x.Invoke(), Times.Never);
-
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result is BadRequestObjectResult);
-        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
     [Theory]
     [MemberData(nameof(GetExecuteParameters))]
-    public async Task Execute_ValidationThrows_ReturnsBadRequest(bool useCancellationToken, string? action, float? score)
+    public async Task Execute_ValidationThrows_PropagatesException(bool useCancellationToken, string? action, float? score)
     {
+        var validationException = new Exception();
+
         (var tokenExtractionService, var verificationService, var validationService) = RecaptchaAttributeFixture.CreateServices(
             RecaptchaAttributeFixture.Token,
             new VerifyResponse(),
-            validationException: new Exception());
+            validationException: validationException);
 
         var options = RecaptchaAttributeFixture.GetRecaptchaOptions(useCancellationToken);
 
@@ -238,15 +229,12 @@ public class AttributeTest
 
         var attribute = score.HasValue ? new RecaptchaAttribute(action!, score.Value) : new RecaptchaAttribute(action!);
 
-        await attribute.OnActionExecutionAsync(context, next.Object);
+        var thrown = await Assert.ThrowsAsync<RecaptchaUnknownException>(() => attribute.OnActionExecutionAsync(context, next.Object));
+        Assert.Same(validationException, thrown.InnerException);
 
-        VerifyServicesCalls(tokenExtractionService, verificationService, validationService, true, useCancellationToken, action, score);
+        tokenExtractionService.Verify(x => x.GetToken(It.IsAny<ActionExecutingContext>()), Times.Once);
 
         next.Verify(x => x.Invoke(), Times.Never);
-
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result is BadRequestObjectResult);
-        Assert.Equal(StatusCodes.Status400BadRequest, (context.Result as BadRequestObjectResult)!.StatusCode);
     }
 
     private static void VerifyServicesCalls(

--- a/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
+++ b/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
@@ -46,10 +46,10 @@ public class RecaptchaAttribute : ActionFilterAttribute
     /// <param name="next">A delegate that contains next action.</param>
     public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        var recaptchaOptions = context.HttpContext.RequestServices.GetRequiredService<IOptions<RecaptchaOptions>>().Value;
-
         try
         {
+            var recaptchaOptions = context.HttpContext.RequestServices.GetRequiredService<IOptions<RecaptchaOptions>>().Value;
+
             var result = await ProcessRecaptchaAsync(context, recaptchaOptions);
 
             if (result is not null)
@@ -60,19 +60,7 @@ public class RecaptchaAttribute : ActionFilterAttribute
         }
         catch (Exception e) when (e is not RecaptchaServiceException)
         {
-            context.Result =
-                recaptchaOptions.AttributeOptions.OnReturnBadRequest?.Invoke(context, _action, null, null, e) ??
-                recaptchaOptions.AttributeOptions.OnException?.Invoke(context, _action, null, e) ??
-                new BadRequestObjectResult(recaptchaOptions.VerificationFailedMessage);
-            return;
-        }
-        catch (RecaptchaServiceException e)
-        {
-            context.Result =
-                recaptchaOptions.AttributeOptions.OnReturnBadRequest?.Invoke(context, _action, null, e, null) ??
-                recaptchaOptions.AttributeOptions.OnRecaptchaServiceException?.Invoke(context, _action, null, e) ??
-                new BadRequestObjectResult(recaptchaOptions.VerificationFailedMessage);
-            return;
+            throw new RecaptchaUnknownException(e);
         }
 
         await base.OnActionExecutionAsync(context, next);
@@ -96,8 +84,7 @@ public class RecaptchaAttribute : ActionFilterAttribute
 
         if (!validationResult.Success)
         {
-            return recaptchaOptions.AttributeOptions.OnReturnBadRequest?.Invoke(context, _action, validationResult, null, null) ??
-                recaptchaOptions.AttributeOptions.OnVerificationFailed?.Invoke(context, _action, validationResult) ??
+            return recaptchaOptions.AttributeOptions.OnVerificationFailed?.Invoke(context, _action, validationResult) ??
                 new BadRequestObjectResult(recaptchaOptions.VerificationFailedMessage);
         }
 

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaAttributeOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaAttributeOptions.cs
@@ -50,29 +50,4 @@ public class RecaptchaAttributeOptions
     /// <para>Any exception could be thrown and will be propagated further.</para>
     /// </summary>
     public virtual Func<ActionExecutingContext, string?, ValidationResult?, IActionResult>? OnVerificationFailed { get; set; }
-
-    /// <summary>
-    /// Delegate for handling thrown <see cref="RecaptchaServiceException"/> during verification of reCAPTCHA response token.
-    /// <para>Returned <see cref="IActionResult"/> will be returned for whole request.</para>
-    /// <para>Any exception could be thrown and will be propagated further.</para>
-    /// </summary>
-    [Obsolete("Deprecated. Will be removed in future versions.")]
-    public virtual Func<ActionExecutingContext, string?, ValidationResult?, RecaptchaServiceException, IActionResult>? OnRecaptchaServiceException { get; set; }
-
-    /// <summary>
-    /// Delegate for handling thrown <see cref="Exception"/> during verification of reCAPTCHA response token.
-    /// <para>Returned <see cref="IActionResult"/> will be returned for whole request.</para>
-    /// <para>Any exception could be thrown and will be propagated further.</para>
-    /// </summary>
-    [Obsolete("Deprecated. Will be removed in future versions.")]
-    public virtual Func<ActionExecutingContext, string?, ValidationResult?, Exception, IActionResult>? OnException { get; set; }
-
-    /// <summary>
-    /// Delegate for handling any bad result of verification.
-    /// <para>Returned <see cref="IActionResult"/> will be returned for whole request.</para>
-    /// <para>Any exception could be thrown and will be propagated further.</para>
-    /// <para>Fires after <see cref="OnVerificationFailed"/>, <see cref="OnRecaptchaServiceException"/> and <see cref="OnException"/>.</para>
-    /// </summary>
-    [Obsolete("Deprecated. Will be removed in future versions.")]
-    public virtual Func<ActionExecutingContext, string?, ValidationResult?, RecaptchaServiceException?, Exception?, IActionResult>? OnReturnBadRequest { get; set; }
 }

--- a/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/Program.cs
+++ b/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/Program.cs
@@ -1,3 +1,4 @@
+using Recaptcha.Verify.Net.AspNetCoreAngular.Server;
 using Recaptcha.Verify.Net.AspNetCoreAngular.Server.Models;
 using Recaptcha.Verify.Net.Configuration;
 
@@ -18,8 +19,12 @@ builder.Services
 builder.Services.AddLogging();
 
 builder.Services.AddControllers();
+builder.Services.AddExceptionHandler<RecaptchaExceptionHandler>();
+builder.Services.AddProblemDetails();
 
 var app = builder.Build();
+
+app.UseExceptionHandler();
 
 app.UseDefaultFiles();
 app.MapStaticAssets();

--- a/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/RecaptchaExceptionHandler.cs
+++ b/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/RecaptchaExceptionHandler.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Recaptcha.Verify.Net.Exceptions;
+using Recaptcha.Verify.Net.Exceptions.Configuration;
+using Recaptcha.Verify.Net.Exceptions.Processing;
+
+namespace Recaptcha.Verify.Net.AspNetCoreAngular.Server;
+
+public class RecaptchaExceptionHandler(IHostEnvironment environment, ILogger<RecaptchaExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (exception is not RecaptchaServiceException recaptchaException)
+        {
+            return false;
+        }
+
+        logger.LogError(recaptchaException, "reCAPTCHA service exception occurred");
+
+        var statusCode = recaptchaException switch
+        {
+            RecaptchaServiceConfigurationException => StatusCodes.Status500InternalServerError,
+            RecaptchaServiceProcessingException => StatusCodes.Status400BadRequest,
+            _ => StatusCodes.Status500InternalServerError
+        };
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = "reCAPTCHA verification failed",
+            Detail = environment.IsDevelopment() ? recaptchaException.ToString() : null
+        };
+
+        httpContext.Response.StatusCode = statusCode;
+
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Changes

- Remove obsolete delegates (`OnReturnBadRequest`, `OnRecaptchaServiceException`, `OnException`) from `RecaptchaAttributeOptions` and `RecaptchaAttribute`
- Exceptions now propagate from `RecaptchaAttribute` instead of being caught
- Non-`RecaptchaServiceException` exceptions are wrapped in `RecaptchaUnknownException`
- Update attribute tests to expect propagated exceptions
- Add `IExceptionHandler` example for ASP.NET Core
- Update README