### PR TITLE
Update README and fix stale doc references for v3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recaptcha.Verify.Net
 [![NuGet](https://img.shields.io/nuget/v/Recaptcha.Verify.Net.svg)](https://www.nuget.org/packages/Recaptcha.Verify.Net)
-[![Build 3.0](https://github.com/vese/Recaptcha.Verify.Net/actions/workflows/build.yml/badge.svg?branch=release/v3.0&event=push)](https://github.com/vese/Recaptcha.Verify.Net/actions/workflows/build.yml?query=branch%3Arelease%2Fv3.0)
+[![Build 3.1](https://github.com/vese/Recaptcha.Verify.Net/actions/workflows/build.yml/badge.svg?branch=release/v3.1&event=push)](https://github.com/vese/Recaptcha.Verify.Net/actions/workflows/build.yml?query=branch%3Arelease%2Fv3.1)
 
 A lightweight library for server-side verification of Google reCAPTCHA v2 and v3 response tokens in .NET applications.
 
@@ -8,6 +8,7 @@ Starting with version 3.0.0, Recaptcha.Verify.Net supports the following platfor
 - .NET 8
 - .NET 9
 - .NET 10
+- .NET 11
 
 For .NET Framework or for other older .NET versions, please use a version below 3.0.0.
 
@@ -116,6 +117,7 @@ The service returns a `VerifyResponse` object containing verification details.
 |Property|Type|Description|
 |---|---|---|
 |`Success`|`bool`|Indicates whether this request was a valid reCAPTCHA token for your site|
+|`IsV3`|`bool`|Indicates whether this is a reCAPTCHA v3 verification (based on score presence)|
 |`Score`|`float?`|**reCAPTCHA v3 only**: Confidence score from 0.0 (likely bot) to 1.0 (likely human)|
 |`Action`|`string?`|**reCAPTCHA v3 only**: The action name specified during client-side execution|
 |`ChallengeTs`|`DateTime`|Timestamp when the challenge was loaded|
@@ -246,7 +248,7 @@ Delegate may also throw exceptions, which will not be caught by `RecaptchaAttrib
 
 When an exception occurs during verification, a `RecaptchaServiceException`-derived exception is thrown (see [Handling Exceptions](#handling-exceptions) for the full list).
 These exceptions are not caught by `RecaptchaAttribute` and propagate up the ASP.NET request pipeline, where they are handled according to the application's configured exception handling rules.
-See the [ASP.NET Core example](https://github.com/vese/Recaptcha.Verify.Net/tree/release/v3.0/examples/Recaptcha.Verify.Net.AspNetCoreAngular) for a reference implementation.
+See the [ASP.NET Core example](https://github.com/vese/Recaptcha.Verify.Net/tree/release/v3.1/examples/Recaptcha.Verify.Net.AspNetCoreAngular) for a reference implementation.
 
 ## Handling Exceptions
 Library can produce following exceptions
@@ -267,5 +269,5 @@ Exception | Description
 
 ## Examples
 Examples could be found in library repository:
-- [**Recaptcha.Verify.Net.ConsoleApp**](https://github.com/vese/Recaptcha.Verify.Net/blob/v3.0/examples/Recaptcha.Verify.Net.ConsoleApp/Program.cs) (.NET 10)
-- [**Recaptcha.Verify.Net.AspNetCoreAngular**](https://github.com/vese/Recaptcha.Verify.Net/tree/release/v3.0/examples/Recaptcha.Verify.Net.AspNetCoreAngular) (ASP.NET + Angular)
+- [**Recaptcha.Verify.Net.ConsoleApp**](https://github.com/vese/Recaptcha.Verify.Net/blob/release/v3.1/examples/Recaptcha.Verify.Net.ConsoleApp/Program.cs) (.NET 10)
+- [**Recaptcha.Verify.Net.AspNetCoreAngular**](https://github.com/vese/Recaptcha.Verify.Net/tree/release/v3.1/examples/Recaptcha.Verify.Net.AspNetCoreAngular) (ASP.NET + Angular)

--- a/Recaptcha.Verify.Net.Test/TestCases.md
+++ b/Recaptcha.Verify.Net.Test/TestCases.md
@@ -1,0 +1,80 @@
+# Test Cases
+
+## Attribute Tests (`Attribute/AttributeTest.cs`)
+
+Tests for `RecaptchaAttribute` behavior in various scenarios.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `Execute_NoTokenExtractionService_ThrowsRecaptchaUnknownException` | Fact | When no `IRecaptchaTokenExtractionService` is registered, throws `RecaptchaUnknownException` with inner `InvalidOperationException`. Action pipeline is not invoked. |
+| 2 | `Execute_TokenExtractionServiceThrowsTokenExtractorNotFound_PropagatesException` | Fact | When token extraction service throws `TokenExtractorNotFound`, the exception propagates. Action pipeline is not invoked. |
+| 3 | `Execute_TokenExtractionServiceThrowsEmptyCaptchaAnswer_PropagatesException` | Fact | When token extraction service throws `EmptyCaptchaAnswerException`, the exception propagates. Action pipeline is not invoked. |
+| 4 | `Execute_v2_Successful` | Theory | Successful v2 flow: token extracted, verification succeeds, validation passes. Action pipeline invoked once, no result set. Parameters: `useCancellationToken` ∈ {false, true}. |
+| 5 | `Execute_v3_Successful` | Theory | Successful v3 flow with all combinations of `useCancellationToken` × `action` × `score`. Action pipeline invoked once, no result set. 8 parameter combinations. |
+| 6 | `Execute_Unsuccessful_ReturnsBadRequest` | Theory | When validation returns unsuccessful, sets `BadRequestObjectResult` (400). Action pipeline not invoked. 8 parameter combinations. |
+| 7 | `Execute_VerificationThrows_PropagatesException` | Theory | When verification service throws, it is wrapped in `RecaptchaUnknownException` with original as `InnerException`. Token extraction was called, action pipeline not invoked. 8 parameter combinations. |
+| 8 | `Execute_ValidationThrows_PropagatesException` | Theory | When validation service throws, it is wrapped in `RecaptchaUnknownException` with original as `InnerException`. Token extraction was called, action pipeline not invoked. 8 parameter combinations. |
+
+## Configuration Extensions Tests (`Configuration/ConfigurationExtensionsTest.cs`)
+
+Tests for `AddRecaptcha` service registration and `RecaptchaClient` base URL configuration.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `AddRecaptcha_DefaultBaseUrl_WhenNotSpecified` | Fact | When `BaseUrl` is not set, `RecaptchaClient` uses default Google URL `https://www.google.com/recaptcha/api/`. |
+| 2 | `AddRecaptcha_CustomBaseUrl_WhenSpecified` | Fact | When custom `BaseUrl` is specified, `RecaptchaClient` is configured with that URL (trailing slash appended). |
+| 3 | `AddRecaptcha_DefaultBaseUrl_WhenNullOrEmpty` | Theory | When `BaseUrl` is null, empty, or whitespace, `RecaptchaClient` falls back to default Google URL. Parameters: `baseUrl` ∈ {null, "", "   "}. |
+| 4 | `AddRecaptcha_AppendsTrailingSlash_WhenMissing` | Fact | If custom `BaseUrl` does not end with `/`, one is automatically appended. |
+| 5 | `AddRecaptcha_PreservesTrailingSlash_WhenPresent` | Fact | If custom `BaseUrl` already ends with `/`, it is preserved as-is (no double slash). |
+
+## Token Extraction Tests (`TokenExtraction/TokenExtractionTest.cs`)
+
+Tests for individual token extractor implementations.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `Extract_FromActionArguments_WithAction` | Fact | `ActionArgumentsTokenExtractor` with lambda extracts token from action arguments. |
+| 2 | `Extract_FromActionArguments_WithName` | Fact | `ActionArgumentsTokenExtractor` with parameter name extracts token from action arguments by key. |
+| 3 | `Extract_FromExecutingContext` | Fact | `ExecutingContextTokenExtractor` extracts token from `ActionExecutingContext`. |
+| 4 | `Extract_FromForm` | Fact | `FormTokenExtractor` extracts token from HTTP form data by field name. |
+| 5 | `Extract_FromHeader` | Fact | `HeaderTokenExtractor` extracts token from HTTP request headers by header name. |
+| 6 | `Extract_FromQuery` | Fact | `QueryTokenExtractor` extracts token from HTTP query string by parameter name. |
+
+## Token Extraction Service Tests (`TokenExtraction/TokenExtractionServiceTest.cs`)
+
+Tests for `RecaptchaTokenExtractionService` — first-wins token extraction strategy.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `GetToken_NoExtractors_ThrowsTokenExtractorNotFound` | Fact | Calling `GetToken` with no registered extractors throws `TokenExtractorNotFound`. |
+| 2 | `GetToken_AllExtractorsReturnEmpty_ThrowsEmptyCaptchaAnswer` | Fact | When all extractors return null/empty/whitespace, throws `EmptyCaptchaAnswerException`. |
+| 3 | `GetToken_SingleExtractorReturnsToken_ReturnsToken` | Fact | When a single extractor returns a valid token, the service returns it. |
+| 4 | `GetToken_FirstEmptySecondReturnsToken_ReturnsToken` | Fact | When the first extractor returns null and the second returns a valid token, the service returns the second one (fallback). |
+| 5 | `GetToken_FirstWins_SecondExtractorNotCalled` | Fact | When the first extractor returns a valid token, the second extractor is never called (short-circuit). |
+
+## Verification Service Tests (`TokenVerification/VerificationServiceTest.cs`)
+
+Tests for `RecaptchaVerificationService` — token verification via Google's API.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `Verify_MissingSecretKey_Throws` | Theory | Calling `VerifyAsync` with null/empty/whitespace secret key throws `SecretKeyNotSpecifiedException`. Parameters: `secretKey` ∈ {null, "", "   "}. |
+| 2 | `Verify_EmptyResponse_Throws` | Theory | Calling `VerifyAsync` with null/empty/whitespace response token throws `EmptyCaptchaAnswerException`. Parameters: `response` ∈ {null, "", "   "}. |
+| 3 | `Verify_ClientException_Throws` | Fact | When the HTTP client throws during verification, the service wraps it in `VerifyRequestException`. |
+| 4 | `Verify_InvalidResponseToken_ReturnsVerificationResult` | Fact | Using an invalid response token returns `VerifyResponse` with `Success=false`. |
+| 5 | `Verify_ValidResponseToken_ReturnsVerificationResult` | Theory | Using a valid response token returns `VerifyResponse` with `Success=true` and expected score. Parameters: valid tokens from fixture. |
+
+## Validation Service Tests (`VerificationResultValidation/ValidationServiceTest.cs`)
+
+Tests for `RecaptchaVerificationResultValidationService` — verification result validation logic.
+
+| # | Test | Type | Description |
+|---|---|---|---|
+| 1 | `Validate_v3_EmptyAction_Throws` | Theory | Calling `Validate` with empty/null/whitespace action on v3 result throws `EmptyActionException`. Tests both direct and constructor-based action passing. Parameters: `action` ∈ {null, "", "   "}. |
+| 2 | `Validate_v3_ScoreNotSpecified_Throws` | Fact | When no score threshold is configured (globally or per-action), validating a v3 result throws `MinScoreNotSpecifiedException`. Tests both options-based and direct-call paths. |
+| 3 | `Validate_v3_UnsuccessfulVerification` | Fact | Unsuccessful verification produces `ValidationResult` with all flags false: `IsV3=false`, `ResponseSuccessful=false`, `ActionMatches=false`, `ScoreSatisfies=false`, `Success=false`. |
+| 4 | `Validate_v2_SuccessfulVerification` | Fact | Successful v2 verification (no score/action) produces `IsV3=false`, `ResponseSuccessful=true`, `ActionMatches=false`, `ScoreSatisfies=false`, `Success=true`. |
+| 5 | `Validate_v3_SuccessfulVerification_WithScoreThreshold` | Theory | v3 validation with global score threshold via options. Checks `IsV3=true`, `ResponseSuccessful=true`, `ActionMatches=true`, and `ScoreSatisfies`/`Success` based on score vs threshold. Parameters: verification results with varying scores. |
+| 6 | `Validate_v3_SuccessfulVerification_WithActionsScoreThresholds` | Theory | v3 validation with per-action score thresholds via `ActionsScoreThresholds`. Same assertions as above but using action-to-score mappings. Parameters: verification results with varying scores. |
+| 7 | `Validate_v3_SuccessfulVerification_WithScoreThresholdDirectly` | Theory | v3 validation when action and score are passed directly to `Validate`. Confirms score-satisfies logic with direct parameters. Parameters: verification results with varying scores. |
+| 8 | `Validate_v3_SuccessfulVerification_WithScoreThresholdDirectly_OverridesFromOptions` | Theory | Directly passed action/score override values from options. Service is initialized with different options but direct parameters take precedence. Parameters: verification results with varying scores. |

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
@@ -43,9 +43,7 @@ public class RecaptchaOptions
     /// <summary>
     /// Default returning message for unsuccessful validation and checking.
     /// <para>
-    /// This message would be replaced by value processed by <see cref="RecaptchaAttributeOptions.OnVerificationFailed"/>, 
-    /// <see cref="RecaptchaAttributeOptions.OnRecaptchaServiceException"/>, <see cref="RecaptchaAttributeOptions.OnException"/>
-    /// or <see cref="RecaptchaAttributeOptions.OnReturnBadRequest"/>.
+    /// This message would be replaced by value processed by <see cref="RecaptchaAttributeOptions.OnVerificationFailed"/>.
     /// </para>
     /// </summary>
     public string VerificationFailedMessage { get; set; } = "Recaptcha verification failed";


### PR DESCRIPTION
## Changes

- Add .NET 11 to supported platforms list
- Add missing `IsV3` property to `VerifyResponse` table
- Update build badge from v3.0 to v3.1
- Update example links from v3.0 to v3.1
- Remove stale `cref` references to deleted obsolete delegates in `RecaptchaOptions.cs`
- Add `TestCases.md` with description of all test cases