### PR TITLE
Add TokenExtractors configuration and restructure options into focused per-service groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ The package is available on [NuGet](https://www.nuget.org/packages/Recaptcha.Ver
    ```json
    {
      "Recaptcha": {
-       "SecretKey": "<recaptcha secret key>",
-       "AttributeOptions": {
-         "ResponseTokenNameInHeader": "X-Recaptcha-Token",
+       "Verification": {
+         "SecretKey": "<recaptcha secret key>"
+       },
+       "TokenExtractors": {
+         "Header": "X-Recaptcha-Token"
        }
      }
    }
@@ -73,8 +75,7 @@ The verification of a reCAPTCHA response token consists of three sequential step
 1. Validating the verification result
 
 ### Extracting reCAPTCHA Response Token
-Token extraction is performed by services implementing the `IRecaptchaTokenExtractor` interface.
-The `RecaptchaAttribute` uses registered extractors sequentially until the first one successfully retrieves a token.
+Token extraction is coordinated by the `RecaptchaTokenExtractionService`, which iterates the registered `IRecaptchaTokenExtractor` implementations and returns the first non-empty token (first-wins strategy).
 
 #### Built-in Extractors
 The library provides these extractors out of the box:
@@ -88,16 +89,20 @@ The library provides these extractors out of the box:
 |`ExecutingContextTokenExtractor`|Extracts token from the executing context|`services.AddRecaptchaExecutingContextTokenExtractor(delegate)`|
 
 #### Auto-registration via Configuration
-When using `services.AddRecaptcha()`, extractors are automatically registered based on provided configuration `RecaptchaOptions.AttributeOptions`:
-- if `ResponseTokenNameInForm` is not empty then registers `FormTokenExtractor`;
-- if `ResponseTokenNameInHeader` is not empty then registers `HeaderTokenExtractor`;
-- if `ResponseTokenNameInQuery` is not empty then registers `QueryTokenExtractor`;
-- if `GetResponseTokenFromActionArguments` delegate is not empty then registers `ActionArgumentsTokenExtractor`;
-- if `GetResponseTokenFromExecutingContext` delegate is not empty then registers `ExecutingContextTokenExtractor`.
+When using `services.AddRecaptcha()`, extractors are automatically registered based on provided configuration.
+Configure token extractors in `RecaptchaOptions.TokenExtractors`:
+- if `TokenExtractors.Header` is not empty then registers `HeaderTokenExtractor`;
+- if `TokenExtractors.Form` is not empty then registers `FormTokenExtractor`;
+- if `TokenExtractors.Query` is not empty then registers `QueryTokenExtractor` (not recommended for security reasons);
+- if `TokenExtractors.ActionArgument` is not empty then registers `ActionArgumentsTokenExtractor`.
+
+For delegate-based extractors that cannot be configured via JSON, set them in code on `RecaptchaOptions.TokenExtractors`:
+- if `TokenExtractors.GetResponseTokenFromActionArguments` delegate is not empty then registers `ActionArgumentsTokenExtractor`;
+- if `TokenExtractors.GetResponseTokenFromExecutingContext` delegate is not empty then registers `ExecutingContextTokenExtractor`.
 
 #### Important Notes
-- Query Parameters: Avoid using `QueryTokenExtractor` as tokens in URLs may be logged or cached. Prefer headers or body.
-- Request Body: Use `ActionArgumentsTokenExtractor` for body tokens, since the request stream is already read and models are populated by this stage.
+- Query Parameters: Avoid using `QueryTokenExtractor`, as tokens in URLs may be logged or cached. Prefer headers or the request body.
+- Request Body: For tokens sent in the request body, use `ActionArgumentsTokenExtractor`. By the time the attribute runs, model binding has already parsed the body into the controller method arguments, so the token can be read from a bound argument (or a property of a bound model) without re-reading the request stream. To read raw fields from form-encoded data instead, use `FormTokenExtractor` (`Request.Form`).
 - Custom Logic: For complex extraction scenarios, either:
   - Use `ExecutingContextTokenExtractor` with delegate;
   - Implement your own `IRecaptchaTokenExtractor` and register it in the DI container.
@@ -144,11 +149,11 @@ This is performed by the `RecaptchaVerificationResultValidationService`.
 For reCAPTCHA v3 (detected by the presence of a Score value), the service checks:
 - **Action Matching**: Ensures the returned action matches the expected value
   - Provided in the `RecaptchaAttribute` constructor
-  - Global action `RecaptchaOptions.Action`
+  - Global action `RecaptchaOptions.Validation.Action`
 - **Score Threshold**: Ensures the confidence score meets the required threshold
   - Provided in the `RecaptchaAttribute` constructor
-  - Global threshold `RecaptchaOptions.ScoreThreshold`
-  - Action-specific threshold specified in `RecaptchaOptions.ActionsScoreThresholds` dictionary
+  - Global threshold `RecaptchaOptions.Validation.ScoreThreshold`
+  - Action-specific threshold specified in `RecaptchaOptions.Validation.ActionsScoreThresholds` dictionary
 
 The service returns a `ValidationResult` object with detailed validation status.
 
@@ -172,22 +177,24 @@ The system follows this priority order (highest to lowest):
 
 **For Actions**:
 1. `RecaptchaAttribute` constructor value
-1. `RecaptchaOptions.Action` - global default action for all v3 validations
+1. `RecaptchaOptions.Validation.Action` - global default action for all v3 validations
 
 **For Score Thresholds**:
 - `RecaptchaAttribute` constructor value
-- `RecaptchaOptions.ActionsScoreThresholds[action]` - action-specific thresholds map
-- `RecaptchaOptions.ScoreThreshold` - global default score threshold (By default, you can use a threshold of 0.5)
+- `RecaptchaOptions.Validation.ActionsScoreThresholds[action]` - action-specific thresholds map
+- `RecaptchaOptions.Validation.ScoreThreshold` - global default score threshold (By default, you can use a threshold of 0.5)
 
 ### Configuring Actions and Score Thresholds Example
 ```json
 {
   "Recaptcha": {
-    "Action": "default_action",
-    "ScoreThreshold": 0.5,
-    "ActionsScoreThresholds": {
-      "login": 0.8,
-      "comment": 0.3
+    "Validation": {
+      "Action": "default_action",
+      "ScoreThreshold": 0.5,
+      "ActionsScoreThresholds": {
+        "login": 0.8,
+        "comment": 0.3
+      }
     }
   }
 }
@@ -212,16 +219,18 @@ public IActionResult AddComment() { ... }
 
 ## Custom Verification URL
 By default, the library communicates with Google's reCAPTCHA API at `https://www.google.com/recaptcha/api`.
-To use a custom endpoint (e.g. a mirror or proxy), set the `BaseUrl` option in `RecaptchaOptions`:
+To use a custom endpoint (e.g. a mirror or proxy), set the `BaseUrl` option in `RecaptchaOptions.Verification`:
 
 ### Via appsettings.json
 ```json
 {
   "Recaptcha": {
-    "SecretKey": "<recaptcha secret key>",
-    "BaseUrl": "https://recaptcha-proxy.example.com/recaptcha/api",
-    "AttributeOptions": {
-      "ResponseTokenNameInHeader": "X-Recaptcha-Token"
+    "Verification": {
+      "SecretKey": "<recaptcha secret key>",
+      "BaseUrl": "https://recaptcha-proxy.example.com/recaptcha/api"
+    },
+    "TokenExtractors": {
+      "Header": "X-Recaptcha-Token"
     }
   }
 }
@@ -231,8 +240,8 @@ To use a custom endpoint (e.g. a mirror or proxy), set the `BaseUrl` option in `
 ```csharp
 services.AddRecaptcha(o =>
 {
-    o.SecretKey = "<recaptcha secret key>";
-    o.BaseUrl = "https://recaptcha-proxy.example.com/recaptcha/api";
+    o.Verification.SecretKey = "<recaptcha secret key>";
+    o.Verification.BaseUrl = "https://recaptcha-proxy.example.com/recaptcha/api";
 });
 ```
 
@@ -240,9 +249,9 @@ When `BaseUrl` is not specified, the default Google endpoint is used.
 
 ## Response Customization
 When reCAPTCHA verification fails, the library returns a `400 Bad Request` response by default.
-Message specified in `RecaptchaOptions.VerificationFailedMessage` which default value is "Recaptcha verification failed".
+Message specified in `RecaptchaOptions.Attribute.VerificationFailedMessage` which default value is "Recaptcha verification failed".
 
-You can customize the response by setting the `RecaptchaOptions.OnVerificationFailed` delegate, which is called when token verification or validation fails.
+You can customize the response by setting the `RecaptchaOptions.Attribute.OnVerificationFailed` delegate, which is called when token verification or validation fails.
 The `IActionResult` returned by this delegate is used as the HTTP response.
 Delegate may also throw exceptions, which will not be caught by `RecaptchaAttribute`.
 
@@ -260,7 +269,7 @@ Exception | Description
 `MinScoreNotSpecifiedException` | This exception is thrown when minimal score was not specified and request had score value (used V3 reCAPTCHA).
 `SecretKeyNotSpecifiedException` | This exception is thrown when secret key was not specified in options or request params.
 `TokenExtractorNotFound` | This exception is thrown when no ITokenExtractor implementation is registered in DI.
-`RecaptchaServiceProcessingException` | Base recaptcha exception for errors while processing token verification and result checking.
+`RecaptchaServiceProcessingException` | Base recaptcha exception for errors while processing token verification and result verification.
 `EmptyCaptchaAnswerException` | This exception is thrown when captcha answer passed in function is empty.
 `EmptyResponseException` | This exception is thrown when verification request response is empty. When thrown, it is wrapped in VerifyRequestException.
 `VerifyRequestException` | This exception is thrown when verification request failed. Stores inner exception.

--- a/Recaptcha.Verify.Net.Test/Attribute/ActionExecutingContextFixture.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/ActionExecutingContextFixture.cs
@@ -19,7 +19,7 @@ internal class ActionExecutingContextFixture
     public static readonly IPAddress IPAddress = new(int.MaxValue);
 
     public static (ActionExecutingContext context, Mock<ActionExecutionDelegate> nextMock) CreateActionExecutingContext(
-        RecaptchaOptions? options,
+        RecaptchaAttributeOptions? options,
         IRecaptchaTokenExtractionService? tokenExtractionService,
         IRecaptchaVerificationService? verificationService,
         IRecaptchaVerificationResultValidationService? validationService)
@@ -49,7 +49,7 @@ internal class ActionExecutingContextFixture
     }
 
     private static HttpContextMock CreateHttpContext(
-        RecaptchaOptions? options,
+        RecaptchaAttributeOptions? options,
         IRecaptchaTokenExtractionService? tokenExtractionService,
         IRecaptchaVerificationService? verificationService,
         IRecaptchaVerificationResultValidationService? validationService)

--- a/Recaptcha.Verify.Net.Test/Attribute/RecaptchaAttributeFixture.cs
+++ b/Recaptcha.Verify.Net.Test/Attribute/RecaptchaAttributeFixture.cs
@@ -19,12 +19,9 @@ internal static class RecaptchaAttributeFixture
     public const string Action = "Action";
     public const float Score = 0.5f;
 
-    public static RecaptchaOptions GetRecaptchaOptions(bool useCancellationToken = false) => new()
+    public static RecaptchaAttributeOptions GetRecaptchaOptions(bool useCancellationToken = false) => new()
     {
-        AttributeOptions = new()
-        {
-            UseCancellationToken = useCancellationToken
-        }
+        UseCancellationToken = useCancellationToken
     };
 
     public static RecaptchaServices CreateServices(string? token,

--- a/Recaptcha.Verify.Net.Test/Configuration/ConfigurationExtensionsTest.cs
+++ b/Recaptcha.Verify.Net.Test/Configuration/ConfigurationExtensionsTest.cs
@@ -1,5 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Recaptcha.Verify.Net.Configuration;
+using Recaptcha.Verify.Net.TokenExtraction;
 using Recaptcha.Verify.Net.TokenVerification.Client;
 using Xunit;
 
@@ -14,14 +18,14 @@ public class ConfigurationExtensionsTest
 
     [Fact]
     public void AddRecaptcha_DefaultBaseUrl_WhenNotSpecified() =>
-        AssertBaseAddress(DefaultBaseUrl, o => o.SecretKey = SecretKey);
+        AssertBaseAddress(DefaultBaseUrl, o => o.Verification.SecretKey = SecretKey);
 
     [Fact]
     public void AddRecaptcha_CustomBaseUrl_WhenSpecified() =>
         AssertBaseAddress(CustomBaseUrlWithSlash, o =>
         {
-            o.SecretKey = SecretKey;
-            o.BaseUrl = CustomBaseUrl;
+            o.Verification.SecretKey = SecretKey;
+            o.Verification.BaseUrl = CustomBaseUrl;
         });
 
     [Theory]
@@ -31,30 +35,322 @@ public class ConfigurationExtensionsTest
     public void AddRecaptcha_DefaultBaseUrl_WhenNullOrEmpty(string? baseUrl) =>
         AssertBaseAddress(DefaultBaseUrl, o =>
         {
-            o.SecretKey = SecretKey;
-            o.BaseUrl = baseUrl;
+            o.Verification.SecretKey = SecretKey;
+            o.Verification.BaseUrl = baseUrl;
         });
 
     [Fact]
     public void AddRecaptcha_AppendsTrailingSlash_WhenMissing() =>
         AssertBaseAddress(CustomBaseUrlWithSlash, o =>
         {
-            o.SecretKey = SecretKey;
-            o.BaseUrl = CustomBaseUrl;
+            o.Verification.SecretKey = SecretKey;
+            o.Verification.BaseUrl = CustomBaseUrl;
         });
 
     [Fact]
     public void AddRecaptcha_PreservesTrailingSlash_WhenPresent() =>
         AssertBaseAddress(CustomBaseUrlWithSlash, o =>
         {
-            o.SecretKey = SecretKey;
-            o.BaseUrl = CustomBaseUrlWithSlash;
+            o.Verification.SecretKey = SecretKey;
+            o.Verification.BaseUrl = CustomBaseUrlWithSlash;
         });
+
+    [Fact]
+    public void AddRecaptcha_RegistersNestedOptionsAsFocused()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.Verification.BaseUrl = CustomBaseUrl;
+            o.Validation.Action = "login";
+            o.Validation.ScoreThreshold = 0.5f;
+            o.Validation.ActionsScoreThresholds = new Dictionary<string, float> { ["login"] = 0.8f };
+            o.Attribute.UseCancellationToken = false;
+            o.Attribute.VerificationFailedMessage = "Custom message";
+            o.Attribute.OnVerificationFailed = (_, _, _) => new EmptyResult();
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var verificationOptions = provider.GetRequiredService<IOptions<RecaptchaVerificationOptions>>().Value;
+        Assert.Equal(SecretKey, verificationOptions.SecretKey);
+        Assert.Equal(CustomBaseUrl, verificationOptions.BaseUrl);
+
+        var validationOptions = provider.GetRequiredService<IOptions<RecaptchaValidationOptions>>().Value;
+        Assert.Equal("login", validationOptions.Action);
+        Assert.Equal(0.5f, validationOptions.ScoreThreshold);
+        Assert.Equal(0.8f, validationOptions.ActionsScoreThresholds!["login"]);
+
+        var attributeOptions = provider.GetRequiredService<IOptions<RecaptchaAttributeOptions>>().Value;
+        Assert.False(attributeOptions.UseCancellationToken);
+        Assert.Equal("Custom message", attributeOptions.VerificationFailedMessage);
+        Assert.NotNull(attributeOptions.OnVerificationFailed);
+    }
+
+    [Fact]
+    public void AddRecaptcha_LegacyFlatOptions_FlowThroughObsoleteProxy()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+#pragma warning disable CS0618 // Verify backward compatibility of the obsolete flat root fields
+        services.AddRecaptcha(o =>
+        {
+            o.SecretKey = SecretKey;
+            o.Action = "login";
+            o.ScoreThreshold = 0.5f;
+            o.VerificationFailedMessage = "Custom message";
+        });
+#pragma warning restore CS0618
+
+        using var provider = services.BuildServiceProvider();
+
+        var verificationOptions = provider.GetRequiredService<IOptions<RecaptchaVerificationOptions>>().Value;
+        Assert.Equal(SecretKey, verificationOptions.SecretKey);
+
+        var validationOptions = provider.GetRequiredService<IOptions<RecaptchaValidationOptions>>().Value;
+        Assert.Equal("login", validationOptions.Action);
+        Assert.Equal(0.5f, validationOptions.ScoreThreshold);
+
+        var attributeOptions = provider.GetRequiredService<IOptions<RecaptchaAttributeOptions>>().Value;
+        Assert.Equal("Custom message", attributeOptions.VerificationFailedMessage);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_Header_RegistersHeaderExtractor()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.Header = "X-Recaptcha-Token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<HeaderTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_Form_RegistersFormExtractor()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.Form = "recaptchaToken";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<FormTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_Query_RegistersQueryExtractor()
+    {
+#pragma warning disable CS0618 // Query is obsolete (not secure), verifying backward-compatible registration
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.Query = "recaptchaToken";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<QueryTokenExtractor>(extractors[0]);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_ActionArgumentsDelegate_RegistersExtractor()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.GetResponseTokenFromActionArguments = _ => "token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<ActionArgumentsTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_ActionArgumentName_RegistersExtractor()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.ActionArgument = "recaptchaToken";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<ActionArgumentsTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_ExecutingContextDelegate_RegistersExtractor()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.GetResponseTokenFromExecutingContext = _ => "token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<ExecutingContextTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_TakesPrecedenceOverAttributeOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+#pragma warning disable CS0618
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.TokenExtractors.Header = "X-New-Header";
+            o.AttributeOptions.ResponseTokenNameInHeader = "X-Old-Header";
+        });
+#pragma warning restore CS0618
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+    }
+
+    [Fact]
+    public void AddRecaptcha_FallsBackToAttributeOptions_WhenTokenExtractorsEmpty()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+#pragma warning disable CS0618
+        services.AddRecaptcha(o =>
+        {
+            o.Verification.SecretKey = SecretKey;
+            o.AttributeOptions.ResponseTokenNameInHeader = "X-Old-Header";
+        });
+#pragma warning restore CS0618
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Single(extractors);
+        Assert.IsType<HeaderTokenExtractor>(extractors[0]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_TokenExtractors_FromConfigurationSection()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Recaptcha:Verification:SecretKey", SecretKey },
+                { "Recaptcha:TokenExtractors:Header", "X-Recaptcha-Token" },
+                { "Recaptcha:TokenExtractors:Form", "recaptchaToken" },
+                { "Recaptcha:TokenExtractors:Query", "recaptchaToken" },
+                { "Recaptcha:TokenExtractors:ActionArgument", "recaptchaToken" },
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddRecaptcha(config.GetSection("Recaptcha"));
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Equal(4, extractors.Count);
+        Assert.Contains(extractors, e => e is HeaderTokenExtractor);
+        Assert.Contains(extractors, e => e is FormTokenExtractor);
+#pragma warning disable CS0618 // QueryTokenExtractor is obsolete (not secure)
+        Assert.Contains(extractors, e => e is QueryTokenExtractor);
+#pragma warning restore CS0618
+        Assert.Contains(extractors, e => e is ActionArgumentsTokenExtractor);
+
+        var verificationOptions = provider.GetRequiredService<IOptions<RecaptchaVerificationOptions>>().Value;
+        Assert.Equal(SecretKey, verificationOptions.SecretKey);
+    }
+
+    [Fact]
+    public void AddRecaptcha_ActionsScoreThresholds_BindsFromNestedConfigurationSection()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Recaptcha:Verification:SecretKey", SecretKey },
+                { "Recaptcha:Validation:ActionsScoreThresholds:login", "0.8" },
+                { "Recaptcha:Validation:ActionsScoreThresholds:comment", "0.3" },
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddRecaptcha(config.GetSection("Recaptcha"));
+
+        using var provider = services.BuildServiceProvider();
+        var validationOptions = provider.GetRequiredService<IOptions<RecaptchaValidationOptions>>().Value;
+
+        Assert.NotNull(validationOptions.ActionsScoreThresholds);
+        Assert.Equal(0.8f, validationOptions.ActionsScoreThresholds!["login"]);
+        Assert.Equal(0.3f, validationOptions.ActionsScoreThresholds!["comment"]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_ActionsScoreThresholds_BindsFromLegacyFlatConfigurationSection()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Recaptcha:Verification:SecretKey", SecretKey },
+                { "Recaptcha:ActionsScoreThresholds:login", "0.8" },
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddRecaptcha(config.GetSection("Recaptcha"));
+
+        using var provider = services.BuildServiceProvider();
+        var validationOptions = provider.GetRequiredService<IOptions<RecaptchaValidationOptions>>().Value;
+
+        Assert.NotNull(validationOptions.ActionsScoreThresholds);
+        Assert.Equal(0.8f, validationOptions.ActionsScoreThresholds!["login"]);
+    }
+
+    [Fact]
+    public void AddRecaptcha_NoExtractors_WhenNothingConfigured()
+    {
+        var services = new ServiceCollection();
+        services.AddRecaptcha(o => o.Verification.SecretKey = SecretKey);
+
+        using var provider = services.BuildServiceProvider();
+        var extractors = provider.GetServices<IRecaptchaTokenExtractor>().ToList();
+
+        Assert.Empty(extractors);
+    }
 
     private static void AssertBaseAddress(string expectedUrl, Action<RecaptchaOptions> configure)
     {
         var services = new ServiceCollection();
-        services.AddLogging();
         services.AddRecaptcha(configure);
 
         using var provider = services.BuildServiceProvider();

--- a/Recaptcha.Verify.Net.Test/Recaptcha.Verify.Net.Test.csproj
+++ b/Recaptcha.Verify.Net.Test/Recaptcha.Verify.Net.Test.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="HttpContextMoq" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Recaptcha.Verify.Net.Test/TestCases.md
+++ b/Recaptcha.Verify.Net.Test/TestCases.md
@@ -17,15 +17,29 @@ Tests for `RecaptchaAttribute` behavior in various scenarios.
 
 ## Configuration Extensions Tests (`Configuration/ConfigurationExtensionsTest.cs`)
 
-Tests for `AddRecaptcha` service registration and `RecaptchaClient` base URL configuration.
+Tests for `AddRecaptcha` service registration: nested options wiring, `RecaptchaClient` base URL configuration, token-extractor auto-registration, and backward compatibility.
 
 | # | Test | Type | Description |
 |---|---|---|---|
-| 1 | `AddRecaptcha_DefaultBaseUrl_WhenNotSpecified` | Fact | When `BaseUrl` is not set, `RecaptchaClient` uses default Google URL `https://www.google.com/recaptcha/api/`. |
-| 2 | `AddRecaptcha_CustomBaseUrl_WhenSpecified` | Fact | When custom `BaseUrl` is specified, `RecaptchaClient` is configured with that URL (trailing slash appended). |
-| 3 | `AddRecaptcha_DefaultBaseUrl_WhenNullOrEmpty` | Theory | When `BaseUrl` is null, empty, or whitespace, `RecaptchaClient` falls back to default Google URL. Parameters: `baseUrl` ∈ {null, "", "   "}. |
-| 4 | `AddRecaptcha_AppendsTrailingSlash_WhenMissing` | Fact | If custom `BaseUrl` does not end with `/`, one is automatically appended. |
-| 5 | `AddRecaptcha_PreservesTrailingSlash_WhenPresent` | Fact | If custom `BaseUrl` already ends with `/`, it is preserved as-is (no double slash). |
+| 1 | `AddRecaptcha_DefaultBaseUrl_WhenNotSpecified` | Fact | When `Verification.BaseUrl` is not set, `RecaptchaClient` uses default Google URL `https://www.google.com/recaptcha/api/`. |
+| 2 | `AddRecaptcha_CustomBaseUrl_WhenSpecified` | Fact | When custom `Verification.BaseUrl` is specified, `RecaptchaClient` is configured with that URL (trailing slash appended). |
+| 3 | `AddRecaptcha_DefaultBaseUrl_WhenNullOrEmpty` | Theory | When `Verification.BaseUrl` is null, empty, or whitespace, `RecaptchaClient` falls back to default Google URL. Parameters: `baseUrl` ∈ {null, "", "   "}. |
+| 4 | `AddRecaptcha_AppendsTrailingSlash_WhenMissing` | Fact | If custom `Verification.BaseUrl` does not end with `/`, one is automatically appended. |
+| 5 | `AddRecaptcha_PreservesTrailingSlash_WhenPresent` | Fact | If custom `Verification.BaseUrl` already ends with `/`, it is preserved as-is (no double slash). |
+| 6 | `AddRecaptcha_RegistersNestedOptionsAsFocused` | Fact | Settings on the nested `Verification`/`Validation`/`Attribute` groups are registered as the corresponding focused `IOptions<>` (`SecretKey`, `Action`/`ScoreThreshold`, `UseCancellationToken`/`VerificationFailedMessage`). |
+| 7 | `AddRecaptcha_LegacyFlatOptions_FlowThroughObsoleteProxy` | Fact | The obsolete flat root fields still flow through the proxies into the same focused options (backward compatibility). |
+| 8 | `AddRecaptcha_TokenExtractors_Header_RegistersHeaderExtractor` | Fact | Setting `TokenExtractors.Header` registers a single `HeaderTokenExtractor`. |
+| 9 | `AddRecaptcha_TokenExtractors_Form_RegistersFormExtractor` | Fact | Setting `TokenExtractors.Form` registers a single `FormTokenExtractor`. |
+| 10 | `AddRecaptcha_TokenExtractors_Query_RegistersQueryExtractor` | Fact | Setting `TokenExtractors.Query` registers a single `QueryTokenExtractor` (not recommended for security; covered for backward compatibility). |
+| 11 | `AddRecaptcha_TokenExtractors_ActionArgumentsDelegate_RegistersExtractor` | Fact | Setting `TokenExtractors.GetResponseTokenFromActionArguments` registers a single `ActionArgumentsTokenExtractor`. |
+| 12 | `AddRecaptcha_TokenExtractors_ActionArgumentName_RegistersExtractor` | Fact | Setting `TokenExtractors.ActionArgument` registers a single `ActionArgumentsTokenExtractor` (extracts token by action argument name). |
+| 13 | `AddRecaptcha_TokenExtractors_ExecutingContextDelegate_RegistersExtractor` | Fact | Setting `TokenExtractors.GetResponseTokenFromExecutingContext` registers a single `ExecutingContextTokenExtractor`. |
+| 14 | `AddRecaptcha_TokenExtractors_TakesPrecedenceOverAttributeOptions` | Fact | When both `TokenExtractors.Header` and legacy `AttributeOptions.ResponseTokenNameInHeader` are set, only one extractor is registered (new value wins). |
+| 15 | `AddRecaptcha_FallsBackToAttributeOptions_WhenTokenExtractorsEmpty` | Fact | When `TokenExtractors.Header` is empty, the legacy `AttributeOptions.ResponseTokenNameInHeader` is used (backward compatibility). |
+| 16 | `AddRecaptcha_TokenExtractors_FromConfigurationSection` | Fact | `Verification:SecretKey` and `TokenExtractors:Header`/`Form`/`Query`/`ActionArgument` bind from an `IConfigurationSection` and register the corresponding extractors. |
+| 17 | `AddRecaptcha_ActionsScoreThresholds_BindsFromNestedConfigurationSection` | Fact | `Validation:ActionsScoreThresholds` binds automatically from an `IConfigurationSection` into `RecaptchaValidationOptions.ActionsScoreThresholds` (no explicit bind line needed). |
+| 18 | `AddRecaptcha_ActionsScoreThresholds_BindsFromLegacyFlatConfigurationSection` | Fact | Legacy flat `ActionsScoreThresholds` at root binds into `RecaptchaValidationOptions.ActionsScoreThresholds` via the obsolete root proxy (backward compatibility). |
+| 19 | `AddRecaptcha_NoExtractors_WhenNothingConfigured` | Fact | With no token-extractor configuration, no `IRecaptchaTokenExtractor` is registered. |
 
 ## Token Extraction Tests (`TokenExtraction/TokenExtractionTest.cs`)
 

--- a/Recaptcha.Verify.Net.Test/TokenExtraction/TokenExtractionTest.cs
+++ b/Recaptcha.Verify.Net.Test/TokenExtraction/TokenExtractionTest.cs
@@ -64,10 +64,12 @@ public class TokenExtractionTest
     [Fact]
     public void Extract_FromQuery()
     {
+#pragma warning disable CS0618 // QueryTokenExtractor is obsolete (not secure)
         var context = ActionExecutingContextFixture.CreateActionExecutingContext();
 
         var extractor = new QueryTokenExtractor(ActionExecutingContextFixture.QueryTokenName);
         var resultToken = extractor.GetToken(context);
+#pragma warning restore CS0618
 
         Assert.Equal(ActionExecutingContextFixture.QueryTokenValue, resultToken);
     }

--- a/Recaptcha.Verify.Net.Test/TokenVerification/VerificationServiceFixture.cs
+++ b/Recaptcha.Verify.Net.Test/TokenVerification/VerificationServiceFixture.cs
@@ -10,13 +10,13 @@ internal static class VerificationServiceFixture
 {
     public static IRecaptchaVerificationService Create(string secretKey, bool clientThrowException = false)
     {
-        var recaptchaOptions = new RecaptchaOptions
+        var verificationOptions = new RecaptchaVerificationOptions
         {
             SecretKey = secretKey
         };
 
         return new RecaptchaVerificationService(
-            Options.Create(recaptchaOptions),
+            Options.Create(verificationOptions),
             RecaptchaClientFixture.Create(clientThrowException),
             NullLoggerFactory.Instance.CreateLogger<RecaptchaVerificationService>());
     }

--- a/Recaptcha.Verify.Net.Test/VerificationResultValidation/ValidationServiceFixture.cs
+++ b/Recaptcha.Verify.Net.Test/VerificationResultValidation/ValidationServiceFixture.cs
@@ -11,7 +11,7 @@ internal static class ValidationServiceFixture
     public static IRecaptchaVerificationResultValidationService Create(string? action, float? scoreThreshold,
         IReadOnlyDictionary<string, float>? actionsScoreThresholds)
     {
-        var recaptchaOptions = new RecaptchaOptions
+        var validationOptions = new RecaptchaValidationOptions
         {
             Action = action,
             ScoreThreshold = scoreThreshold,
@@ -19,7 +19,7 @@ internal static class ValidationServiceFixture
         };
 
         return new RecaptchaVerificationResultValidationService(
-            Options.Create(recaptchaOptions),
+            Options.Create(validationOptions),
             NullLoggerFactory.Instance.CreateLogger<RecaptchaVerificationResultValidationService>());
     }
 }

--- a/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
+++ b/Recaptcha.Verify.Net/Attribute/RecaptchaAttribute.cs
@@ -48,9 +48,9 @@ public class RecaptchaAttribute : ActionFilterAttribute
     {
         try
         {
-            var recaptchaOptions = context.HttpContext.RequestServices.GetRequiredService<IOptions<RecaptchaOptions>>().Value;
+            var options = context.HttpContext.RequestServices.GetRequiredService<IOptions<RecaptchaAttributeOptions>>().Value;
 
-            var result = await ProcessRecaptchaAsync(context, recaptchaOptions);
+            var result = await ProcessRecaptchaAsync(context, options);
 
             if (result is not null)
             {
@@ -66,7 +66,7 @@ public class RecaptchaAttribute : ActionFilterAttribute
         await base.OnActionExecutionAsync(context, next);
     }
 
-    private async Task<IActionResult?> ProcessRecaptchaAsync(ActionExecutingContext context, RecaptchaOptions recaptchaOptions)
+    private async Task<IActionResult?> ProcessRecaptchaAsync(ActionExecutingContext context, RecaptchaAttributeOptions options)
     {
         var tokenExtractionService = context.HttpContext.RequestServices.GetRequiredService<IRecaptchaTokenExtractionService>();
         var recaptchaToken = tokenExtractionService.GetToken(context);
@@ -75,7 +75,7 @@ public class RecaptchaAttribute : ActionFilterAttribute
         var validationService = context.HttpContext.RequestServices.GetRequiredService<IRecaptchaVerificationResultValidationService>();
 
         var remoteIp = context.HttpContext.Connection.RemoteIpAddress?.MapToIPv4().ToString();
-        var cancellationToken = recaptchaOptions.AttributeOptions.UseCancellationToken ?
+        var cancellationToken = options.UseCancellationToken ?
             context.HttpContext.RequestAborted : CancellationToken.None;
 
         var verifyResponse = await verificationService.VerifyAsync(recaptchaToken, remoteIp, cancellationToken);
@@ -84,8 +84,8 @@ public class RecaptchaAttribute : ActionFilterAttribute
 
         if (!validationResult.Success)
         {
-            return recaptchaOptions.AttributeOptions.OnVerificationFailed?.Invoke(context, _action, validationResult) ??
-                new BadRequestObjectResult(recaptchaOptions.VerificationFailedMessage);
+            return options.OnVerificationFailed?.Invoke(context, _action, validationResult) ??
+                new BadRequestObjectResult(options.VerificationFailedMessage);
         }
 
         return null;

--- a/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
+++ b/Recaptcha.Verify.Net/Configuration/ConfigurationExtensions.cs
@@ -30,7 +30,6 @@ public static class ConfigurationExtensions
     {
         var recaptchaOptions = new RecaptchaOptions();
         section.Bind(recaptchaOptions);
-        section.GetSection(nameof(RecaptchaOptions.ActionsScoreThresholds)).Bind(recaptchaOptions.ActionsScoreThresholds);
 
         return services.AddRecaptcha(recaptchaOptions, configuration);
     }
@@ -44,41 +43,66 @@ public static class ConfigurationExtensions
     public static IServiceCollection AddRecaptcha(this IServiceCollection services, RecaptchaOptions recaptchaOptions, Action<RecaptchaOptions>? configuration = null)
     {
         configuration?.Invoke(recaptchaOptions);
-        services.AddSingleton(Options.Create(recaptchaOptions));
+
+        services.AddOptionsForServices(recaptchaOptions);
 
         services.AddTokenExtractorForOptions(recaptchaOptions);
 
-        services.ConfigureService(recaptchaOptions.BaseUrl);
+        services.ConfigureService(recaptchaOptions.Verification.BaseUrl);
 
         return services;
     }
 
+    private static void AddOptionsForServices(this IServiceCollection services, RecaptchaOptions options)
+    {
+        services.AddSingleton(Options.Create(options.Verification));
+        services.AddSingleton(Options.Create(options.Validation));
+        services.AddSingleton(Options.Create(options.Attribute));
+    }
+
     private static void AddTokenExtractorForOptions(this IServiceCollection services, RecaptchaOptions options)
     {
-        if (!string.IsNullOrEmpty(options.AttributeOptions.ResponseTokenNameInHeader))
+        var tokenExtractors = options.TokenExtractors;
+
+#pragma warning disable CS0618 // Suppress obsolete warnings for legacy backward-compatibility fallbacks
+        var legacy = options.AttributeOptions;
+
+        var headerName = tokenExtractors.Header ?? legacy.ResponseTokenNameInHeader;
+        if (!string.IsNullOrEmpty(headerName))
         {
-            services.AddRecaptchaHeaderTokenExtractor(options.AttributeOptions.ResponseTokenNameInHeader);
+            services.AddRecaptchaHeaderTokenExtractor(headerName);
         }
 
-        if (!string.IsNullOrEmpty(options.AttributeOptions.ResponseTokenNameInQuery))
+        var formName = tokenExtractors.Form ?? legacy.ResponseTokenNameInForm;
+        if (!string.IsNullOrEmpty(formName))
         {
-            services.AddRecaptchaQueryTokenExtractor(options.AttributeOptions.ResponseTokenNameInQuery);
+            services.AddRecaptchaFormTokenExtractor(formName);
         }
 
-        if (!string.IsNullOrEmpty(options.AttributeOptions.ResponseTokenNameInForm))
+        var queryName = tokenExtractors.Query ?? legacy.ResponseTokenNameInQuery;
+        if (!string.IsNullOrEmpty(queryName))
         {
-            services.AddRecaptchaFormTokenExtractor(options.AttributeOptions.ResponseTokenNameInForm);
+            services.AddRecaptchaQueryTokenExtractor(queryName);
         }
 
-        if (options.AttributeOptions.GetResponseTokenFromActionArguments is not null)
+        var actionArgumentName = tokenExtractors.ActionArgument;
+        if (!string.IsNullOrEmpty(actionArgumentName))
         {
-            services.AddRecaptchaActionArgumentsTokenExtractor(options.AttributeOptions.GetResponseTokenFromActionArguments);
+            services.AddRecaptchaActionArgumentsTokenExtractor(actionArgumentName);
         }
 
-        if (options.AttributeOptions.GetResponseTokenFromExecutingContext is not null)
+        var fromActionArguments = tokenExtractors.GetResponseTokenFromActionArguments ?? legacy.GetResponseTokenFromActionArguments;
+        if (fromActionArguments is not null)
         {
-            services.AddRecaptchaExecutingContextTokenExtractor(options.AttributeOptions.GetResponseTokenFromExecutingContext);
+            services.AddRecaptchaActionArgumentsTokenExtractor(fromActionArguments);
         }
+
+        var fromExecutingContext = tokenExtractors.GetResponseTokenFromExecutingContext ?? legacy.GetResponseTokenFromExecutingContext;
+        if (fromExecutingContext is not null)
+        {
+            services.AddRecaptchaExecutingContextTokenExtractor(fromExecutingContext);
+        }
+#pragma warning restore CS0618
     }
 
     /// <summary>

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaAttributeOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaAttributeOptions.cs
@@ -1,53 +1,29 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Recaptcha.Verify.Net.Attribute;
 
 namespace Recaptcha.Verify.Net.Configuration;
 
 /// <summary>
-/// <see cref="RecaptchaAttribute"/> options.
+/// Options for <see cref="RecaptchaAttribute"/>.
 /// </summary>
 public class RecaptchaAttributeOptions
 {
     /// <summary>
-    /// <c>True</c> if need to use cancellation token for validation and checking.
+    /// <c>True</c> if need to use cancellation token for validation and verification.
     /// <para>Default value is <c>True</c>.</para>
     /// </summary>
     public bool UseCancellationToken { get; set; } = true;
 
     /// <summary>
-    /// Name of reCAPTCHA response token param in request header.
+    /// Default returning message for unsuccessful validation and verification.
     /// </summary>
-    public string? ResponseTokenNameInHeader { get; set; }
-
-    /// <summary>
-    /// Name of reCAPTCHA response token param in request query.
-    /// </summary>
-    [Obsolete("Do not pass token in query parameters. It is not secure.")]
-    public string? ResponseTokenNameInQuery { get; set; }
-
-    /// <summary>
-    /// Name of reCAPTCHA response token param in request form data.
-    /// </summary>
-    public string? ResponseTokenNameInForm { get; set; }
-
-    /// <summary>
-    /// Delegate for getting reCAPTCHA response token from action arguments.
-    /// Actions argumets are mapped arguments of controller method.
-    /// </summary>
-    [Obsolete("Use AddRecaptchaActionArgumentsTokenExtractor instead")]
-    public Func<IDictionary<string, object?>, string>? GetResponseTokenFromActionArguments { get; set; }
-
-    /// <summary>
-    /// Delegate for getting reCAPTCHA response token from executing context.
-    /// </summary>
-    [Obsolete("Use AddRecaptchaExecutingContextTokenExtractor instead")]
-    public Func<ActionExecutingContext, string>? GetResponseTokenFromExecutingContext { get; set; }
+    public string VerificationFailedMessage { get; set; } = "Recaptcha verification failed";
 
     /// <summary>
     /// Delegate for handling failed verification of reCAPTCHA response token.
     /// <para>Returned <see cref="IActionResult"/> will be returned for whole request.</para>
     /// <para>Any exception could be thrown and will be propagated further.</para>
     /// </summary>
-    public virtual Func<ActionExecutingContext, string?, ValidationResult?, IActionResult>? OnVerificationFailed { get; set; }
+    public Func<ActionExecutingContext, string?, ValidationResult?, IActionResult>? OnVerificationFailed { get; set; }
 }

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaLegacyAttributeOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaLegacyAttributeOptions.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Recaptcha.Verify.Net.Attribute;
+
+namespace Recaptcha.Verify.Net.Configuration;
+
+/// <summary>
+/// Legacy <see cref="RecaptchaAttribute"/> options. Kept for backward compatibility with the previous
+/// <c>AttributeOptions</c> appsettings structure. Will be removed in a future release.
+/// </summary>
+[Obsolete("Will be removed in a future release. Use root RecaptchaOptions instead.")]
+public class RecaptchaLegacyAttributeOptions
+{
+    /// <summary>
+    /// <c>True</c> if need to use cancellation token for validation and verification.
+    /// <para>Default value is <c>True</c>.</para>
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.Attribute.UseCancellationToken instead.")]
+    public bool UseCancellationToken { get; set; } = true;
+
+    /// <summary>
+    /// Name of reCAPTCHA response token param in request header.
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.TokenExtractors.Header instead.")]
+    public string? ResponseTokenNameInHeader { get; set; }
+
+    /// <summary>
+    /// Name of reCAPTCHA response token param in request query.
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.TokenExtractors.Query instead. Do not pass token in query parameters. It is not secure.")]
+    public string? ResponseTokenNameInQuery { get; set; }
+
+    /// <summary>
+    /// Name of reCAPTCHA response token param in request form data.
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.TokenExtractors.Form instead.")]
+    public string? ResponseTokenNameInForm { get; set; }
+
+    /// <summary>
+    /// Delegate for getting reCAPTCHA response token from action arguments.
+    /// Actions argumets are mapped arguments of controller method.
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.TokenExtractors.GetResponseTokenFromActionArguments instead.")]
+    public Func<IDictionary<string, object?>, string>? GetResponseTokenFromActionArguments { get; set; }
+
+    /// <summary>
+    /// Delegate for getting reCAPTCHA response token from executing context.
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.TokenExtractors.GetResponseTokenFromExecutingContext instead.")]
+    public Func<ActionExecutingContext, string>? GetResponseTokenFromExecutingContext { get; set; }
+
+    /// <summary>
+    /// Delegate for handling failed verification of reCAPTCHA response token.
+    /// <para>Returned <see cref="IActionResult"/> will be returned for whole request.</para>
+    /// <para>Any exception could be thrown and will be propagated further.</para>
+    /// </summary>
+    [Obsolete("Use RecaptchaOptions.Attribute.OnVerificationFailed instead.")]
+    public Func<ActionExecutingContext, string?, ValidationResult?, IActionResult>? OnVerificationFailed { get; set; }
+}

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaOptions.cs
@@ -1,55 +1,110 @@
-﻿using Recaptcha.Verify.Net.Attribute;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Recaptcha.Verify.Net.Attribute;
+using Recaptcha.Verify.Net.VerificationResultValidation.Models;
 
 namespace Recaptcha.Verify.Net.Configuration;
 
 /// <summary>
-/// Recaptcha options.
+/// Recaptcha options. Root configuration model used for appsettings mapping.
+/// <para>Settings are grouped into focused sub-options: <see cref="Verification"/>, <see cref="Validation"/>,
+/// <see cref="Attribute"/> and <see cref="TokenExtractors"/>.</para>
 /// </summary>
 public class RecaptchaOptions
 {
     /// <summary>
-    /// The shared key between your site and reCAPTCHA.
+    /// Options for token verification with Google's reCAPTCHA API.
     /// </summary>
-    public string SecretKey { get; set; } = null!;
+    public RecaptchaVerificationOptions Verification { get; set; } = new();
+
+    /// <summary>
+    /// Options for validating the reCAPTCHA verification result.
+    /// </summary>
+    public RecaptchaValidationOptions Validation { get; set; } = new();
+
+    /// <summary>
+    /// Options for <see cref="RecaptchaAttribute"/>.
+    /// </summary>
+    public RecaptchaAttributeOptions Attribute { get; set; } = new();
+
+    /// <summary>
+    /// Options for configuring token extractors that retrieve reCAPTCHA response tokens from requests.
+    /// </summary>
+    public RecaptchaTokenExtractorOptions TokenExtractors { get; set; } = new();
 
     /// <summary>
     /// Optional. Custom base URL for the reCAPTCHA verification API endpoint.
-    /// <para>When not specified, defaults to <c>https://www.google.com/recaptcha/api</c>.</para>
-    /// <para>Set this to use a custom endpoint, such as a reCAPTCHA mirror or proxy server.</para>
     /// </summary>
-    public string? BaseUrl { get; set; }
+    [Obsolete($"Use {nameof(Verification)}.{nameof(RecaptchaVerificationOptions.BaseUrl)} instead.")]
+    public string? BaseUrl
+    {
+        get => Verification.BaseUrl;
+        set => Verification.BaseUrl = value;
+    }
+
+    /// <summary>
+    /// Legacy <see cref="RecaptchaAttribute"/> options. Kept for backward compatibility with the previous
+    /// <c>AttributeOptions</c> appsettings structure. Will be removed in a future release.
+    /// </summary>
+    [Obsolete("Will be removed in a future release. Use the corresponding nested options instead.")]
+    public RecaptchaLegacyAttributeOptions AttributeOptions { get; set; } = new();
+
+    /// <summary>
+    /// The shared key between your site and reCAPTCHA.
+    /// </summary>
+    [Obsolete($"Use {nameof(Verification)}.{nameof(RecaptchaVerificationOptions.SecretKey)} instead.")]
+    public string SecretKey
+    {
+        get => Verification.SecretKey;
+        set => Verification.SecretKey = value;
+    }
 
     /// <summary>
     /// Optional. Action to check for V3 Recaptcha request.
     /// <para>Action specified in <see cref="IRecaptchaVerificationResultValidationService.Validate"/>
     /// or in <see cref="RecaptchaAttribute"/> will be used instead of this value.</para>
     /// </summary>
-    public string? Action { get; set; }
+    [Obsolete($"Use {nameof(Validation)}.{nameof(RecaptchaValidationOptions.Action)} instead.")]
+    public string? Action
+    {
+        get => Validation.Action;
+        set => Validation.Action = value;
+    }
 
     /// <summary>
     /// Optional. Score threshold for V3 Recaptcha (0.0 - 1.0).
     /// <para>Score threshold specified in <see cref="IRecaptchaVerificationResultValidationService.Validate"/>
     /// or in <see cref="RecaptchaAttribute"/> will be used instead of this value.</para>
     /// </summary>
-    public float? ScoreThreshold { get; set; }
+    [Obsolete($"Use {nameof(Validation)}.{nameof(RecaptchaValidationOptions.ScoreThreshold)} instead.")]
+    public float? ScoreThreshold
+    {
+        get => Validation.ScoreThreshold;
+        set => Validation.ScoreThreshold = value;
+    }
 
     /// <summary>
     /// Optional. Map of actions score thresholds for V3 Recaptcha.
     /// <para>Score threshold specified in <see cref="IRecaptchaVerificationResultValidationService.Validate"/>
     /// or in <see cref="RecaptchaAttribute"/> will be used instead of this value.</para>
     /// </summary>
-    public IReadOnlyDictionary<string, float>? ActionsScoreThresholds { get; set; }
+    [Obsolete($"Use {nameof(Validation)}.{nameof(RecaptchaValidationOptions.ActionsScoreThresholds)} instead.")]
+    public IReadOnlyDictionary<string, float>? ActionsScoreThresholds
+    {
+        get => Validation.ActionsScoreThresholds;
+        set => Validation.ActionsScoreThresholds = value;
+    }
 
     /// <summary>
-    /// Default returning message for unsuccessful validation and checking.
+    /// Default returning message for unsuccessful validation and verification.
     /// <para>
     /// This message would be replaced by value processed by <see cref="RecaptchaAttributeOptions.OnVerificationFailed"/>.
     /// </para>
     /// </summary>
-    public string VerificationFailedMessage { get; set; } = "Recaptcha verification failed";
-
-    /// <summary>
-    /// Options for <see cref="RecaptchaAttribute"/>.
-    /// </summary>
-    public RecaptchaAttributeOptions AttributeOptions { get; set; } = new RecaptchaAttributeOptions();
+    [Obsolete($"Use {nameof(Attribute)}.{nameof(RecaptchaAttributeOptions.VerificationFailedMessage)} instead.")]
+    public string VerificationFailedMessage
+    {
+        get => Attribute.VerificationFailedMessage;
+        set => Attribute.VerificationFailedMessage = value;
+    }
 }

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaTokenExtractorOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaTokenExtractorOptions.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Recaptcha.Verify.Net.Configuration;
+
+/// <summary>
+/// Options for configuring token extractors that retrieve reCAPTCHA response tokens from requests.
+/// </summary>
+public class RecaptchaTokenExtractorOptions
+{
+    /// <summary>
+    /// Name of the request header that contains the reCAPTCHA response token.
+    /// </summary>
+    public string? Header { get; set; }
+
+    /// <summary>
+    /// Name of the form field that contains the reCAPTCHA response token.
+    /// </summary>
+    public string? Form { get; set; }
+
+    /// <summary>
+    /// Name of the query parameter that contains the reCAPTCHA response token.
+    /// </summary>
+    [Obsolete("Do not pass token in query parameters. It is not secure.")]
+    public string? Query { get; set; }
+
+    /// <summary>
+    /// Name of the action argument that contains the reCAPTCHA response token.
+    /// Action arguments are the mapped arguments of the controller method.
+    /// </summary>
+    public string? ActionArgument { get; set; }
+
+    /// <summary>
+    /// Delegate for getting reCAPTCHA response token from action arguments.
+    /// Actions arguments are mapped arguments of controller method.
+    /// </summary>
+    public Func<IDictionary<string, object?>, string?>? GetResponseTokenFromActionArguments { get; set; }
+
+    /// <summary>
+    /// Delegate for getting reCAPTCHA response token from executing context.
+    /// </summary>
+    public Func<ActionExecutingContext, string?>? GetResponseTokenFromExecutingContext { get; set; }
+}

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaValidationOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaValidationOptions.cs
@@ -1,0 +1,22 @@
+namespace Recaptcha.Verify.Net.Configuration;
+
+/// <summary>
+/// Options for <see cref="VerificationResultValidation.IRecaptchaVerificationResultValidationService"/>.
+/// </summary>
+public class RecaptchaValidationOptions
+{
+    /// <summary>
+    /// Optional. Action to check for V3 Recaptcha request.
+    /// </summary>
+    public string? Action { get; set; }
+
+    /// <summary>
+    /// Optional. Score threshold for V3 Recaptcha (0.0 - 1.0).
+    /// </summary>
+    public float? ScoreThreshold { get; set; }
+
+    /// <summary>
+    /// Optional. Map of actions score thresholds for V3 Recaptcha.
+    /// </summary>
+    public IReadOnlyDictionary<string, float>? ActionsScoreThresholds { get; set; }
+}

--- a/Recaptcha.Verify.Net/Configuration/RecaptchaVerificationOptions.cs
+++ b/Recaptcha.Verify.Net/Configuration/RecaptchaVerificationOptions.cs
@@ -1,0 +1,19 @@
+namespace Recaptcha.Verify.Net.Configuration;
+
+/// <summary>
+/// Options for <see cref="TokenVerification.IRecaptchaVerificationService"/>.
+/// </summary>
+public class RecaptchaVerificationOptions
+{
+    /// <summary>
+    /// The shared key between your site and reCAPTCHA.
+    /// </summary>
+    public string SecretKey { get; set; } = null!;
+
+    /// <summary>
+    /// Optional. Custom base URL for the reCAPTCHA verification API endpoint.
+    /// <para>When not specified, defaults to <c>https://www.google.com/recaptcha/api</c>.</para>
+    /// <para>Set this to use a custom endpoint, such as a reCAPTCHA mirror or proxy server.</para>
+    /// </summary>
+    public string? BaseUrl { get; set; }
+}

--- a/Recaptcha.Verify.Net/TokenVerification/RecaptchaVerificationService.cs
+++ b/Recaptcha.Verify.Net/TokenVerification/RecaptchaVerificationService.cs
@@ -7,17 +7,17 @@ namespace Recaptcha.Verify.Net.TokenVerification;
 /// <summary>
 /// Recaptcha verification service constructor.
 /// </summary>
-/// <param name="recaptchaOptions">Recaptcha options.</param>
+/// <param name="options">Recaptcha verification options.</param>
 /// <param name="recaptchaClient">Recaptcha client.</param>
 /// <param name="logger">Logger.</param>
-internal class RecaptchaVerificationService(IOptions<RecaptchaOptions> recaptchaOptions, IRecaptchaClient recaptchaClient, ILogger<RecaptchaVerificationService> logger) : IRecaptchaVerificationService
+internal class RecaptchaVerificationService(IOptions<RecaptchaVerificationOptions> options, IRecaptchaClient recaptchaClient, ILogger<RecaptchaVerificationService> logger) : IRecaptchaVerificationService
 {
-    private readonly RecaptchaOptions _recaptchaOptions = recaptchaOptions.Value;
+    private readonly RecaptchaVerificationOptions options = options.Value;
 
     /// <inheritdoc />
     public async Task<VerifyResponse> VerifyAsync(string response, string? remoteIp = null, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(_recaptchaOptions.SecretKey))
+        if (string.IsNullOrWhiteSpace(options.SecretKey))
         {
             throw new SecretKeyNotSpecifiedException();
         }
@@ -29,7 +29,7 @@ internal class RecaptchaVerificationService(IOptions<RecaptchaOptions> recaptcha
 
         var request = new VerifyRequest
         {
-            Secret = _recaptchaOptions.SecretKey,
+            Secret = options.SecretKey,
             Response = response,
             RemoteIp = remoteIp
         };

--- a/Recaptcha.Verify.Net/VerificationResultValidation/RecaptchaVerificationResultValidationService.cs
+++ b/Recaptcha.Verify.Net/VerificationResultValidation/RecaptchaVerificationResultValidationService.cs
@@ -7,11 +7,11 @@ namespace Recaptcha.Verify.Net.VerificationResultValidation;
 /// <summary>
 /// Recaptcha verification result validation service constructor.
 /// </summary>
-/// <param name="recaptchaOptions">Recaptcha options.</param>
+/// <param name="options">Recaptcha validation options.</param>
 /// <param name="logger">Logger.</param>
-public class RecaptchaVerificationResultValidationService(IOptions<RecaptchaOptions> recaptchaOptions, ILogger<RecaptchaVerificationResultValidationService> logger) : IRecaptchaVerificationResultValidationService
+public class RecaptchaVerificationResultValidationService(IOptions<RecaptchaValidationOptions> options, ILogger<RecaptchaVerificationResultValidationService> logger) : IRecaptchaVerificationResultValidationService
 {
-    private readonly RecaptchaOptions _recaptchaOptions = recaptchaOptions.Value;
+    private readonly RecaptchaValidationOptions options = options.Value;
 
     /// <inheritdoc />
     public ValidationResult Validate(VerifyResponse response, string? action = null, float? score = null)
@@ -51,9 +51,9 @@ public class RecaptchaVerificationResultValidationService(IOptions<RecaptchaOpti
             return action;
         }
 
-        if (!string.IsNullOrWhiteSpace(_recaptchaOptions.Action))
+        if (!string.IsNullOrWhiteSpace(options.Action))
         {
-            return _recaptchaOptions.Action;
+            return options.Action;
         }
 
         throw new EmptyActionException();
@@ -66,14 +66,14 @@ public class RecaptchaVerificationResultValidationService(IOptions<RecaptchaOpti
             return score.Value;
         }
 
-        if (_recaptchaOptions.ActionsScoreThresholds is not null && _recaptchaOptions.ActionsScoreThresholds.TryGetValue(action, out var scoreThreshold))
+        if (options.ActionsScoreThresholds is not null && options.ActionsScoreThresholds.TryGetValue(action, out var scoreThreshold))
         {
             return scoreThreshold;
         }
 
-        if (_recaptchaOptions is not null && _recaptchaOptions.ScoreThreshold.HasValue)
+        if (options.ScoreThreshold.HasValue)
         {
-            return _recaptchaOptions.ScoreThreshold.Value;
+            return options.ScoreThreshold.Value;
         }
 
         throw new MinScoreNotSpecifiedException(action);

--- a/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/Controllers/LoginController.cs
+++ b/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/Controllers/LoginController.cs
@@ -39,7 +39,7 @@ public class LoginController(
     public async Task<IActionResult> Login_ServicesExample([FromBody] Credentials credentials, CancellationToken cancellationToken)
     {
         var verificationResult = await recaptchaVerificationService.VerifyAsync(
-            credentials.RecaptchaToken,
+            credentials.RecaptchaToken!,
             HttpContext.Connection.RemoteIpAddress?.MapToIPv4().ToString(),
             cancellationToken);
 

--- a/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/appsettings.json
+++ b/examples/Recaptcha.Verify.Net.AspNetCoreAngular/Recaptcha.Verify.Net.AspNetCoreAngular.Server/appsettings.json
@@ -1,18 +1,22 @@
 {
   "Recaptcha": {
-    "SecretKey": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe",
-    "ScoreThreshold": 0.5,
-    "ActionsScoreThresholds": {
-      "login": 0.75,
-      "test": 0.9
+    "Verification": {
+      "SecretKey": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
     },
-    "AttributeOptions": {
+    "Validation": {
+      "ScoreThreshold": 0.5,
+      "ActionsScoreThresholds": {
+        "login": 0.75,
+        "test": 0.9
+      }
+    },
+    "TokenExtractors": {
       // If token is passed in header
-      "ResponseTokenNameInHeader": "X-Recaptcha-Token",
-      // If token is passed in query
-      "ResponseTokenNameInQuery": "RecaptchaTokenInQuery",
+      "Header": "X-Recaptcha-Token",
       // If token is passed in form
-      "ResponseTokenNameInForm": "RecaptchaTokenInForm"
+      "Form": "RecaptchaTokenInForm",
+      // If token is passed in query (not recommended for security reasons)
+      "Query": "RecaptchaTokenInQuery"
     }
   },
   "Logging": {

--- a/examples/Recaptcha.Verify.Net.ConsoleApp/Program.cs
+++ b/examples/Recaptcha.Verify.Net.ConsoleApp/Program.cs
@@ -70,6 +70,6 @@ static ServiceProvider CreateServiceProvider() =>
         })
         .AddRecaptcha(o =>
         {
-            o.ScoreThreshold = 0.5f;
+            o.Validation.ScoreThreshold = 0.5f;
         })
         .BuildServiceProvider();


### PR DESCRIPTION
## Token extractors configuration
- New `RecaptchaOptions.TokenExtractors` section configures token extraction sources.
- Auto-registers extractors from config: `Header`, `Form`, `Query` (not recommended, not secure), `ActionArgument` (by argument name), and delegate-based `GetResponseTokenFromActionArguments` / `GetResponseTokenFromExecutingContext`.
- Extraction is coordinated by `RecaptchaTokenExtractionService` (`IRecaptchaTokenExtractionService`, first-wins).

## Options restructure
- `RecaptchaOptions` exposes focused nested groups: `Verification`, `Validation`, `Attribute`, `TokenExtractors`.
- Services consume focused options: `IOptions<RecaptchaVerificationOptions>`, `IOptions<RecaptchaValidationOptions>`, `IOptions<RecaptchaAttributeOptions>`.

## Backward compatibility
- The previous flat root fields are kept as `[Obsolete]` proxies over the nested groups; old appsettings and code keep working.
- Legacy `AttributeOptions` (`RecaptchaLegacyAttributeOptions`) retained as a fallback for token-extractor names/delegates; moved members marked obsolete.

## Tests and docs
- Added configuration-section and token-extractor registration tests; `TestCases.md` updated.
- README and example apps updated.